### PR TITLE
Enhance install and publish scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,19 +124,17 @@ To contribute to @seasketch/geoprocessing please create a new branch for feature
 
 ## Installation
 
-This repository is setup as a "monorepo" managed by [Lerna](https://github.com/lerna/lerna), with two packages under `packages/`. These include the geoprocessing library itself and an example project that can be used to test functionality. To work on the library, checkout the repo and run lerna bootstrap.
+This repository is setup as a "monorepo" managed by [Lerna](https://github.com/lerna/lerna), with two packages under `packages/`. These include the geoprocessing library itself and an example project that can be used to test functionality. To work on the library, checkout the repo and run the install script.  This will install lerna, bootstrap each package, and prepare an initial build of the geoprocessing library.
 
 ```sh
-mkdir @seasketch && cd @seasketch
 git clone https://github.com/seasketch/geoprocessing.git
 cd geoprocessing
-npx lerna bootstrap
-# bootstrap will install npm dependencies for both and prepare initial build
+npm install
 ```
 
-You should now be able to run unit tests for both packages
+You should now be able to run unit tests for all packages
 ```sh
-npx lerna run test
+npm run test
 ```
 
 ## Editor setup and style guidelines
@@ -170,8 +168,7 @@ The framework has it's own storybook project that can be launched using `npm run
 
 ## Testing integration with project implementations
 
-Testing modifications to the framework, particularly build steps, can be tricky
-because of the varying environments under which the code may run. A good methodology is to first create unit tests and verify that they run, then modify `packages/example-project` and its unit tests and verify the tests run and `npm run build` steps work. It is not uncommon for these steps to pass and for bugs to still appear after publishing of the framework, so manual testing after publishing should be done as well.
+Testing modifications to the framework, particularly build steps, can be tricky because of the varying environments under which the code may run. A good methodology is to first create unit tests and verify that they run, then modify `packages/example-project` and its unit tests and verify the tests run and `npm run build` steps work. It is not uncommon for these steps to pass and for bugs to still appear after publishing of the framework, so manual testing after publishing should be done as well.
 
 To test with projects other than `example-project` on your local machine, npm link is a handy tool. From within `packages/geoprocessing` run the command `npm link`. This will make the library available to other packages locally (assuming the same version of node. watch out nvm users!). Then change to you project directory and run `npm link @seasketch/geoprocessing`. Any changes you make to the library will automatically be reflected in your geoprocessing implementation. Just watch out for a couple common problems:
 
@@ -184,7 +181,20 @@ To test with projects other than `example-project` on your local machine, npm li
 
 ## Publishing
 
-To publish new versions of the framework run `lerna publish`. Please follow [semantic versioning conventions](https://semver.org/).
+To publish a new release of the framework, make sure you are in the `master` branch with no outstanding code changes. Then run the following:
+```sh
+npm run publish
+```
+
+Please follow [semantic versioning conventions](https://semver.org/).  This will generate new build artifacts in the `dist` folder first using the `prepare` script.
+
+### Alpha releases
+
+By default, a release will be tagged as `latest` so that users installing from npm will get it by default.  You can also publish an `alpha` release out-of-band to offer new features out for early testing/adoption.
+
+```sh
+npm run publish:alpha
+```
 
 ## Roadmap
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,11 +11,6 @@
         "typescript": "^3.9.2"
       },
       "devDependencies": {
-        "@turf/buffer": "^5.1.5",
-        "@turf/intersect": "^6.1.3",
-        "@turf/line-intersect": "^6.0.2",
-        "@turf/points-within-polygon": "^5.1.5",
-        "@types/node": "^13.11.1",
         "lerna": "^3.20.2"
       }
     },
@@ -1296,192 +1291,6 @@
         "@types/node": ">= 8"
       }
     },
-    "node_modules/@turf/bbox": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/bbox/-/bbox-5.1.5.tgz",
-      "integrity": "sha1-MFHfUUrUxQ9KT5uKLRX9i2hA7aM=",
-      "dev": true,
-      "dependencies": {
-        "@turf/helpers": "^5.1.5",
-        "@turf/meta": "^5.1.5"
-      }
-    },
-    "node_modules/@turf/boolean-point-in-polygon": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/boolean-point-in-polygon/-/boolean-point-in-polygon-5.1.5.tgz",
-      "integrity": "sha1-8BzBlNHgMKVIv9qYHLpDz9YpQbc=",
-      "dev": true,
-      "dependencies": {
-        "@turf/helpers": "^5.1.5",
-        "@turf/invariant": "^5.1.5"
-      }
-    },
-    "node_modules/@turf/boolean-point-in-polygon/node_modules/@turf/invariant": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/@turf/invariant/-/invariant-5.2.0.tgz",
-      "integrity": "sha1-8BUP9ykLOFd7c9CIt5MsHuCqkKc=",
-      "dev": true,
-      "dependencies": {
-        "@turf/helpers": "^5.1.5"
-      }
-    },
-    "node_modules/@turf/buffer": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/buffer/-/buffer-5.1.5.tgz",
-      "integrity": "sha1-hByWJ8+5dLEirE4alW8EZrwCMcQ=",
-      "dev": true,
-      "dependencies": {
-        "@turf/bbox": "^5.1.5",
-        "@turf/center": "^5.1.5",
-        "@turf/helpers": "^5.1.5",
-        "@turf/meta": "^5.1.5",
-        "@turf/projection": "^5.1.5",
-        "d3-geo": "1.7.1",
-        "turf-jsts": "*"
-      }
-    },
-    "node_modules/@turf/center": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/center/-/center-5.1.5.tgz",
-      "integrity": "sha1-RKss2VT2PA03dX9xWKmcPvURS4A=",
-      "dev": true,
-      "dependencies": {
-        "@turf/bbox": "^5.1.5",
-        "@turf/helpers": "^5.1.5"
-      }
-    },
-    "node_modules/@turf/clone": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/clone/-/clone-5.1.5.tgz",
-      "integrity": "sha1-JT6NNUdxgZduM636tQoPAqfw42c=",
-      "dev": true,
-      "dependencies": {
-        "@turf/helpers": "^5.1.5"
-      }
-    },
-    "node_modules/@turf/helpers": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/helpers/-/helpers-5.1.5.tgz",
-      "integrity": "sha1-FTQFInq5M9AEpbuWQantmZ/L4M8=",
-      "dev": true
-    },
-    "node_modules/@turf/intersect": {
-      "version": "6.1.3",
-      "resolved": "https://registry.npmjs.org/@turf/intersect/-/intersect-6.1.3.tgz",
-      "integrity": "sha1-xldKLwCjjfb4H8CNgQOtUpW3trw=",
-      "dev": true,
-      "dependencies": {
-        "@turf/helpers": "6.x",
-        "@turf/invariant": "6.x",
-        "martinez-polygon-clipping": "^0.4.3"
-      }
-    },
-    "node_modules/@turf/intersect/node_modules/@turf/helpers": {
-      "version": "6.1.4",
-      "resolved": "https://registry.npmjs.org/@turf/helpers/-/helpers-6.1.4.tgz",
-      "integrity": "sha512-vJvrdOZy1ngC7r3MDA7zIGSoIgyrkWcGnNIEaqn/APmw+bVLF2gAW7HIsdTxd12s5wQMqEpqIQrmrbRRZ0xC7g==",
-      "dev": true
-    },
-    "node_modules/@turf/invariant": {
-      "version": "6.1.2",
-      "resolved": "https://registry.npmjs.org/@turf/invariant/-/invariant-6.1.2.tgz",
-      "integrity": "sha1-YBPtYhn5rC7a2psx4d+lkY6wovc=",
-      "dev": true,
-      "dependencies": {
-        "@turf/helpers": "6.x"
-      }
-    },
-    "node_modules/@turf/invariant/node_modules/@turf/helpers": {
-      "version": "6.1.4",
-      "resolved": "https://registry.npmjs.org/@turf/helpers/-/helpers-6.1.4.tgz",
-      "integrity": "sha512-vJvrdOZy1ngC7r3MDA7zIGSoIgyrkWcGnNIEaqn/APmw+bVLF2gAW7HIsdTxd12s5wQMqEpqIQrmrbRRZ0xC7g==",
-      "dev": true
-    },
-    "node_modules/@turf/line-intersect": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/@turf/line-intersect/-/line-intersect-6.0.2.tgz",
-      "integrity": "sha1-tFt6Tn4Iw5oOTpEJlYDtN373M18=",
-      "dev": true,
-      "dependencies": {
-        "@turf/helpers": "6.x",
-        "@turf/invariant": "6.x",
-        "@turf/line-segment": "6.x",
-        "@turf/meta": "6.x",
-        "geojson-rbush": "3.x"
-      }
-    },
-    "node_modules/@turf/line-intersect/node_modules/@turf/helpers": {
-      "version": "6.1.4",
-      "resolved": "https://registry.npmjs.org/@turf/helpers/-/helpers-6.1.4.tgz",
-      "integrity": "sha512-vJvrdOZy1ngC7r3MDA7zIGSoIgyrkWcGnNIEaqn/APmw+bVLF2gAW7HIsdTxd12s5wQMqEpqIQrmrbRRZ0xC7g==",
-      "dev": true
-    },
-    "node_modules/@turf/line-intersect/node_modules/@turf/meta": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/@turf/meta/-/meta-6.0.2.tgz",
-      "integrity": "sha1-65KVESbSSmE6wbe5nXM/zCD9MM8=",
-      "dev": true,
-      "dependencies": {
-        "@turf/helpers": "6.x"
-      }
-    },
-    "node_modules/@turf/line-segment": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/@turf/line-segment/-/line-segment-6.0.2.tgz",
-      "integrity": "sha1-4oC83nDSi2lAKOwWI9xAbJKOWbY=",
-      "dev": true,
-      "dependencies": {
-        "@turf/helpers": "6.x",
-        "@turf/invariant": "6.x",
-        "@turf/meta": "6.x"
-      }
-    },
-    "node_modules/@turf/line-segment/node_modules/@turf/helpers": {
-      "version": "6.1.4",
-      "resolved": "https://registry.npmjs.org/@turf/helpers/-/helpers-6.1.4.tgz",
-      "integrity": "sha512-vJvrdOZy1ngC7r3MDA7zIGSoIgyrkWcGnNIEaqn/APmw+bVLF2gAW7HIsdTxd12s5wQMqEpqIQrmrbRRZ0xC7g==",
-      "dev": true
-    },
-    "node_modules/@turf/line-segment/node_modules/@turf/meta": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/@turf/meta/-/meta-6.0.2.tgz",
-      "integrity": "sha1-65KVESbSSmE6wbe5nXM/zCD9MM8=",
-      "dev": true,
-      "dependencies": {
-        "@turf/helpers": "6.x"
-      }
-    },
-    "node_modules/@turf/meta": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/@turf/meta/-/meta-5.2.0.tgz",
-      "integrity": "sha1-OxrUhe4MOwsXdRMqMsOE1T5LpT0=",
-      "dev": true,
-      "dependencies": {
-        "@turf/helpers": "^5.1.5"
-      }
-    },
-    "node_modules/@turf/points-within-polygon": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/points-within-polygon/-/points-within-polygon-5.1.5.tgz",
-      "integrity": "sha1-K4VaXfOq2lfC7oIKB1SrlJKKIzc=",
-      "dev": true,
-      "dependencies": {
-        "@turf/boolean-point-in-polygon": "^5.1.5",
-        "@turf/helpers": "^5.1.5",
-        "@turf/meta": "^5.1.5"
-      }
-    },
-    "node_modules/@turf/projection": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/projection/-/projection-5.1.5.tgz",
-      "integrity": "sha1-JFF+7rLzaBa6n3EueubWo2jt91c=",
-      "dev": true,
-      "dependencies": {
-        "@turf/clone": "^5.1.5",
-        "@turf/helpers": "^5.1.5",
-        "@turf/meta": "^5.1.5"
-      }
-    },
     "node_modules/@types/events": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@types/events/-/events-3.0.0.tgz",
@@ -2659,21 +2468,6 @@
       "integrity": "sha1-WW6WmP0MgOEgOMK4LW6xs1tiJNk=",
       "dev": true
     },
-    "node_modules/d3-array": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-1.2.4.tgz",
-      "integrity": "sha1-Y1zk1e6nWfb2BYY9vPww7cc39x8=",
-      "dev": true
-    },
-    "node_modules/d3-geo": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/d3-geo/-/d3-geo-1.7.1.tgz",
-      "integrity": "sha1-RLvHohix/YWfPY/XxEPKg2Vpzpk=",
-      "dev": true,
-      "dependencies": {
-        "d3-array": "1"
-      }
-    },
     "node_modules/dargs": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/dargs/-/dargs-4.1.0.tgz",
@@ -3530,33 +3324,6 @@
       "resolved": "https://registry.npmjs.org/genfun/-/genfun-5.0.0.tgz",
       "integrity": "sha1-ndlxCgaQClxKW/V6yl2k5S/nZTc=",
       "dev": true
-    },
-    "node_modules/geojson-rbush": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/geojson-rbush/-/geojson-rbush-3.1.2.tgz",
-      "integrity": "sha1-V31uxwuphtTmC3QfHfUUf664LJc=",
-      "dev": true,
-      "dependencies": {
-        "@turf/bbox": "*",
-        "@turf/helpers": "6.x",
-        "@turf/meta": "6.x",
-        "rbush": "^2.0.0"
-      }
-    },
-    "node_modules/geojson-rbush/node_modules/@turf/helpers": {
-      "version": "6.1.4",
-      "resolved": "https://registry.npmjs.org/@turf/helpers/-/helpers-6.1.4.tgz",
-      "integrity": "sha512-vJvrdOZy1ngC7r3MDA7zIGSoIgyrkWcGnNIEaqn/APmw+bVLF2gAW7HIsdTxd12s5wQMqEpqIQrmrbRRZ0xC7g==",
-      "dev": true
-    },
-    "node_modules/geojson-rbush/node_modules/@turf/meta": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/@turf/meta/-/meta-6.0.2.tgz",
-      "integrity": "sha1-65KVESbSSmE6wbe5nXM/zCD9MM8=",
-      "dev": true,
-      "dependencies": {
-        "@turf/helpers": "6.x"
-      }
     },
     "node_modules/get-caller-file": {
       "version": "2.0.5",
@@ -5139,16 +4906,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/martinez-polygon-clipping": {
-      "version": "0.4.3",
-      "resolved": "https://registry.npmjs.org/martinez-polygon-clipping/-/martinez-polygon-clipping-0.4.3.tgz",
-      "integrity": "sha1-o5cd3x2hRxBLXQ+79o9yi7YohcE=",
-      "dev": true,
-      "dependencies": {
-        "splaytree": "^0.1.4",
-        "tinyqueue": "^1.2.0"
-      }
-    },
     "node_modules/meow": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/meow/-/meow-5.0.0.tgz",
@@ -6300,21 +6057,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/quickselect": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/quickselect/-/quickselect-1.1.1.tgz",
-      "integrity": "sha1-hS5BLOQY8jetW2YNcM/6xkeulMI=",
-      "dev": true
-    },
-    "node_modules/rbush": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/rbush/-/rbush-2.0.2.tgz",
-      "integrity": "sha1-u2AFwnMbe6HVqaA1dykn0WphRgU=",
-      "dev": true,
-      "dependencies": {
-        "quickselect": "^1.0.1"
-      }
-    },
     "node_modules/read": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/read/-/read-1.0.7.tgz",
@@ -7116,12 +6858,6 @@
       "integrity": "sha1-NpS1gEVnpFjTyARYQqY1hjL2JlQ=",
       "dev": true
     },
-    "node_modules/splaytree": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/splaytree/-/splaytree-0.1.4.tgz",
-      "integrity": "sha1-/DVHUkjtzCnUk4ybZ+Q8a35Vplk=",
-      "dev": true
-    },
     "node_modules/split": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/split/-/split-1.0.1.tgz",
@@ -7453,12 +7189,6 @@
         "xtend": "~4.0.1"
       }
     },
-    "node_modules/tinyqueue": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/tinyqueue/-/tinyqueue-1.2.3.tgz",
-      "integrity": "sha1-tqYd4jBgWE2in4I2LkXfHsc1Pz0=",
-      "dev": true
-    },
     "node_modules/tmp": {
       "version": "0.0.33",
       "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
@@ -7580,12 +7310,6 @@
       "engines": {
         "node": "*"
       }
-    },
-    "node_modules/turf-jsts": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/turf-jsts/-/turf-jsts-1.2.3.tgz",
-      "integrity": "sha1-WXV/VCr7/5pXe79BHxg7j0jTiqQ=",
-      "dev": true
     },
     "node_modules/tweetnacl": {
       "version": "0.14.5",
@@ -9267,202 +8991,6 @@
         "@types/node": ">= 8"
       }
     },
-    "@turf/bbox": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/bbox/-/bbox-5.1.5.tgz",
-      "integrity": "sha1-MFHfUUrUxQ9KT5uKLRX9i2hA7aM=",
-      "dev": true,
-      "requires": {
-        "@turf/helpers": "^5.1.5",
-        "@turf/meta": "^5.1.5"
-      }
-    },
-    "@turf/boolean-point-in-polygon": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/boolean-point-in-polygon/-/boolean-point-in-polygon-5.1.5.tgz",
-      "integrity": "sha1-8BzBlNHgMKVIv9qYHLpDz9YpQbc=",
-      "dev": true,
-      "requires": {
-        "@turf/helpers": "^5.1.5",
-        "@turf/invariant": "^5.1.5"
-      },
-      "dependencies": {
-        "@turf/invariant": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/@turf/invariant/-/invariant-5.2.0.tgz",
-          "integrity": "sha1-8BUP9ykLOFd7c9CIt5MsHuCqkKc=",
-          "dev": true,
-          "requires": {
-            "@turf/helpers": "^5.1.5"
-          }
-        }
-      }
-    },
-    "@turf/buffer": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/buffer/-/buffer-5.1.5.tgz",
-      "integrity": "sha1-hByWJ8+5dLEirE4alW8EZrwCMcQ=",
-      "dev": true,
-      "requires": {
-        "@turf/bbox": "^5.1.5",
-        "@turf/center": "^5.1.5",
-        "@turf/helpers": "^5.1.5",
-        "@turf/meta": "^5.1.5",
-        "@turf/projection": "^5.1.5",
-        "d3-geo": "1.7.1",
-        "turf-jsts": "*"
-      }
-    },
-    "@turf/center": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/center/-/center-5.1.5.tgz",
-      "integrity": "sha1-RKss2VT2PA03dX9xWKmcPvURS4A=",
-      "dev": true,
-      "requires": {
-        "@turf/bbox": "^5.1.5",
-        "@turf/helpers": "^5.1.5"
-      }
-    },
-    "@turf/clone": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/clone/-/clone-5.1.5.tgz",
-      "integrity": "sha1-JT6NNUdxgZduM636tQoPAqfw42c=",
-      "dev": true,
-      "requires": {
-        "@turf/helpers": "^5.1.5"
-      }
-    },
-    "@turf/helpers": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/helpers/-/helpers-5.1.5.tgz",
-      "integrity": "sha1-FTQFInq5M9AEpbuWQantmZ/L4M8=",
-      "dev": true
-    },
-    "@turf/intersect": {
-      "version": "6.1.3",
-      "resolved": "https://registry.npmjs.org/@turf/intersect/-/intersect-6.1.3.tgz",
-      "integrity": "sha1-xldKLwCjjfb4H8CNgQOtUpW3trw=",
-      "dev": true,
-      "requires": {
-        "@turf/helpers": "6.x",
-        "@turf/invariant": "6.x",
-        "martinez-polygon-clipping": "^0.4.3"
-      },
-      "dependencies": {
-        "@turf/helpers": {
-          "version": "6.1.4",
-          "resolved": "https://registry.npmjs.org/@turf/helpers/-/helpers-6.1.4.tgz",
-          "integrity": "sha512-vJvrdOZy1ngC7r3MDA7zIGSoIgyrkWcGnNIEaqn/APmw+bVLF2gAW7HIsdTxd12s5wQMqEpqIQrmrbRRZ0xC7g==",
-          "dev": true
-        }
-      }
-    },
-    "@turf/invariant": {
-      "version": "6.1.2",
-      "resolved": "https://registry.npmjs.org/@turf/invariant/-/invariant-6.1.2.tgz",
-      "integrity": "sha1-YBPtYhn5rC7a2psx4d+lkY6wovc=",
-      "dev": true,
-      "requires": {
-        "@turf/helpers": "6.x"
-      },
-      "dependencies": {
-        "@turf/helpers": {
-          "version": "6.1.4",
-          "resolved": "https://registry.npmjs.org/@turf/helpers/-/helpers-6.1.4.tgz",
-          "integrity": "sha512-vJvrdOZy1ngC7r3MDA7zIGSoIgyrkWcGnNIEaqn/APmw+bVLF2gAW7HIsdTxd12s5wQMqEpqIQrmrbRRZ0xC7g==",
-          "dev": true
-        }
-      }
-    },
-    "@turf/line-intersect": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/@turf/line-intersect/-/line-intersect-6.0.2.tgz",
-      "integrity": "sha1-tFt6Tn4Iw5oOTpEJlYDtN373M18=",
-      "dev": true,
-      "requires": {
-        "@turf/helpers": "6.x",
-        "@turf/invariant": "6.x",
-        "@turf/line-segment": "6.x",
-        "@turf/meta": "6.x",
-        "geojson-rbush": "3.x"
-      },
-      "dependencies": {
-        "@turf/helpers": {
-          "version": "6.1.4",
-          "resolved": "https://registry.npmjs.org/@turf/helpers/-/helpers-6.1.4.tgz",
-          "integrity": "sha512-vJvrdOZy1ngC7r3MDA7zIGSoIgyrkWcGnNIEaqn/APmw+bVLF2gAW7HIsdTxd12s5wQMqEpqIQrmrbRRZ0xC7g==",
-          "dev": true
-        },
-        "@turf/meta": {
-          "version": "6.0.2",
-          "resolved": "https://registry.npmjs.org/@turf/meta/-/meta-6.0.2.tgz",
-          "integrity": "sha1-65KVESbSSmE6wbe5nXM/zCD9MM8=",
-          "dev": true,
-          "requires": {
-            "@turf/helpers": "6.x"
-          }
-        }
-      }
-    },
-    "@turf/line-segment": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/@turf/line-segment/-/line-segment-6.0.2.tgz",
-      "integrity": "sha1-4oC83nDSi2lAKOwWI9xAbJKOWbY=",
-      "dev": true,
-      "requires": {
-        "@turf/helpers": "6.x",
-        "@turf/invariant": "6.x",
-        "@turf/meta": "6.x"
-      },
-      "dependencies": {
-        "@turf/helpers": {
-          "version": "6.1.4",
-          "resolved": "https://registry.npmjs.org/@turf/helpers/-/helpers-6.1.4.tgz",
-          "integrity": "sha512-vJvrdOZy1ngC7r3MDA7zIGSoIgyrkWcGnNIEaqn/APmw+bVLF2gAW7HIsdTxd12s5wQMqEpqIQrmrbRRZ0xC7g==",
-          "dev": true
-        },
-        "@turf/meta": {
-          "version": "6.0.2",
-          "resolved": "https://registry.npmjs.org/@turf/meta/-/meta-6.0.2.tgz",
-          "integrity": "sha1-65KVESbSSmE6wbe5nXM/zCD9MM8=",
-          "dev": true,
-          "requires": {
-            "@turf/helpers": "6.x"
-          }
-        }
-      }
-    },
-    "@turf/meta": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/@turf/meta/-/meta-5.2.0.tgz",
-      "integrity": "sha1-OxrUhe4MOwsXdRMqMsOE1T5LpT0=",
-      "dev": true,
-      "requires": {
-        "@turf/helpers": "^5.1.5"
-      }
-    },
-    "@turf/points-within-polygon": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/points-within-polygon/-/points-within-polygon-5.1.5.tgz",
-      "integrity": "sha1-K4VaXfOq2lfC7oIKB1SrlJKKIzc=",
-      "dev": true,
-      "requires": {
-        "@turf/boolean-point-in-polygon": "^5.1.5",
-        "@turf/helpers": "^5.1.5",
-        "@turf/meta": "^5.1.5"
-      }
-    },
-    "@turf/projection": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/projection/-/projection-5.1.5.tgz",
-      "integrity": "sha1-JFF+7rLzaBa6n3EueubWo2jt91c=",
-      "dev": true,
-      "requires": {
-        "@turf/clone": "^5.1.5",
-        "@turf/helpers": "^5.1.5",
-        "@turf/meta": "^5.1.5"
-      }
-    },
     "@types/events": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@types/events/-/events-3.0.0.tgz",
@@ -10455,21 +9983,6 @@
       "integrity": "sha1-WW6WmP0MgOEgOMK4LW6xs1tiJNk=",
       "dev": true
     },
-    "d3-array": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-1.2.4.tgz",
-      "integrity": "sha1-Y1zk1e6nWfb2BYY9vPww7cc39x8=",
-      "dev": true
-    },
-    "d3-geo": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/d3-geo/-/d3-geo-1.7.1.tgz",
-      "integrity": "sha1-RLvHohix/YWfPY/XxEPKg2Vpzpk=",
-      "dev": true,
-      "requires": {
-        "d3-array": "1"
-      }
-    },
     "dargs": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/dargs/-/dargs-4.1.0.tgz",
@@ -11193,35 +10706,6 @@
       "resolved": "https://registry.npmjs.org/genfun/-/genfun-5.0.0.tgz",
       "integrity": "sha1-ndlxCgaQClxKW/V6yl2k5S/nZTc=",
       "dev": true
-    },
-    "geojson-rbush": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/geojson-rbush/-/geojson-rbush-3.1.2.tgz",
-      "integrity": "sha1-V31uxwuphtTmC3QfHfUUf664LJc=",
-      "dev": true,
-      "requires": {
-        "@turf/bbox": "*",
-        "@turf/helpers": "6.x",
-        "@turf/meta": "6.x",
-        "rbush": "^2.0.0"
-      },
-      "dependencies": {
-        "@turf/helpers": {
-          "version": "6.1.4",
-          "resolved": "https://registry.npmjs.org/@turf/helpers/-/helpers-6.1.4.tgz",
-          "integrity": "sha512-vJvrdOZy1ngC7r3MDA7zIGSoIgyrkWcGnNIEaqn/APmw+bVLF2gAW7HIsdTxd12s5wQMqEpqIQrmrbRRZ0xC7g==",
-          "dev": true
-        },
-        "@turf/meta": {
-          "version": "6.0.2",
-          "resolved": "https://registry.npmjs.org/@turf/meta/-/meta-6.0.2.tgz",
-          "integrity": "sha1-65KVESbSSmE6wbe5nXM/zCD9MM8=",
-          "dev": true,
-          "requires": {
-            "@turf/helpers": "6.x"
-          }
-        }
-      }
     },
     "get-caller-file": {
       "version": "2.0.5",
@@ -12503,16 +11987,6 @@
         "object-visit": "^1.0.0"
       }
     },
-    "martinez-polygon-clipping": {
-      "version": "0.4.3",
-      "resolved": "https://registry.npmjs.org/martinez-polygon-clipping/-/martinez-polygon-clipping-0.4.3.tgz",
-      "integrity": "sha1-o5cd3x2hRxBLXQ+79o9yi7YohcE=",
-      "dev": true,
-      "requires": {
-        "splaytree": "^0.1.4",
-        "tinyqueue": "^1.2.0"
-      }
-    },
     "meow": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/meow/-/meow-5.0.0.tgz",
@@ -13473,21 +12947,6 @@
       "integrity": "sha1-Q2CxfGETatOAeDl/8RQW4Ybc+7g=",
       "dev": true
     },
-    "quickselect": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/quickselect/-/quickselect-1.1.1.tgz",
-      "integrity": "sha1-hS5BLOQY8jetW2YNcM/6xkeulMI=",
-      "dev": true
-    },
-    "rbush": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/rbush/-/rbush-2.0.2.tgz",
-      "integrity": "sha1-u2AFwnMbe6HVqaA1dykn0WphRgU=",
-      "dev": true,
-      "requires": {
-        "quickselect": "^1.0.1"
-      }
-    },
     "read": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/read/-/read-1.0.7.tgz",
@@ -14152,12 +13611,6 @@
       "integrity": "sha1-NpS1gEVnpFjTyARYQqY1hjL2JlQ=",
       "dev": true
     },
-    "splaytree": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/splaytree/-/splaytree-0.1.4.tgz",
-      "integrity": "sha1-/DVHUkjtzCnUk4ybZ+Q8a35Vplk=",
-      "dev": true
-    },
     "split": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/split/-/split-1.0.1.tgz",
@@ -14432,12 +13885,6 @@
         "xtend": "~4.0.1"
       }
     },
-    "tinyqueue": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/tinyqueue/-/tinyqueue-1.2.3.tgz",
-      "integrity": "sha1-tqYd4jBgWE2in4I2LkXfHsc1Pz0=",
-      "dev": true
-    },
     "tmp": {
       "version": "0.0.33",
       "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
@@ -14534,12 +13981,6 @@
       "requires": {
         "safe-buffer": "^5.0.1"
       }
-    },
-    "turf-jsts": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/turf-jsts/-/turf-jsts-1.2.3.tgz",
-      "integrity": "sha1-WXV/VCr7/5pXe79BHxg7j0jTiqQ=",
-      "dev": true
     },
     "tweetnacl": {
       "version": "0.14.5",

--- a/package.json
+++ b/package.json
@@ -3,15 +3,14 @@
   "private": true,
   "license": "BSD-3-Clause",
   "devDependencies": {
-    "@turf/buffer": "^5.1.5",
-    "@turf/intersect": "^6.1.3",
-    "@turf/line-intersect": "^6.0.2",
-    "@turf/points-within-polygon": "^5.1.5",
-    "@types/node": "^13.11.1",
     "lerna": "^3.20.2"
   },
   "scripts": {
     "clean": "git clean -fdx",
+    "postinstall": "lerna bootstrap",
+    "test": "lerna run test",
+    "publish": "CI=1 lerna bootstrap && lerna publish",
+    "publish:alpha": "CI=1 lerna bootstrap && lerna publish --canary --preid alpha --npm-tag=alpha",
     "create_example": "node packages/geoprocessing/dist/scripts/init/createExampleProject.js"
   },
   "dependencies": {

--- a/packages/geoprocessing/package-lock.json
+++ b/packages/geoprocessing/package-lock.json
@@ -31,11 +31,13 @@
 				"@turf/boolean-overlap": "^6.0.1",
 				"@turf/buffer": "^5.1.5",
 				"@turf/combine": "^6.0.1",
+				"@turf/distance": "^6.3.0",
 				"@turf/flatten": "^5.1.5",
 				"@turf/helpers": "^6.1.4",
 				"@turf/intersect": "^6.1.3",
 				"@turf/invariant": "^6.1.2",
 				"@turf/length": "^6.0.2",
+				"@turf/meta": "^6.3.0",
 				"@turf/rewind": "^5.1.5",
 				"@turf/union": "^6.0.3",
 				"@types/aws-lambda": "^8.10.51",
@@ -3905,12 +3907,12 @@
 			}
 		},
 		"node_modules/@turf/distance": {
-			"version": "6.0.1",
-			"resolved": "https://registry.npmjs.org/@turf/distance/-/distance-6.0.1.tgz",
-			"integrity": "sha512-q7t7rWIWfkg7MP1Vt4uLjSEhe5rPfCO2JjpKmk7JC+QZKEQkuvHEqy3ejW1iC7Kw5ZcZNR3qdMGGz+6HnVwqvg==",
+			"version": "6.3.0",
+			"resolved": "https://registry.npmjs.org/@turf/distance/-/distance-6.3.0.tgz",
+			"integrity": "sha512-basi24ssNFnH3iXPFjp/aNUrukjObiFWoIyDRqKyBJxVwVOwAWvfk4d38QQyBj5nDo5IahYRq/Q+T47/5hSs9w==",
 			"dependencies": {
-				"@turf/helpers": "6.x",
-				"@turf/invariant": "6.x"
+				"@turf/helpers": "^6.3.0",
+				"@turf/invariant": "^6.3.0"
 			}
 		},
 		"node_modules/@turf/flatten": {
@@ -3936,9 +3938,9 @@
 			}
 		},
 		"node_modules/@turf/helpers": {
-			"version": "6.1.4",
-			"resolved": "https://registry.npmjs.org/@turf/helpers/-/helpers-6.1.4.tgz",
-			"integrity": "sha512-vJvrdOZy1ngC7r3MDA7zIGSoIgyrkWcGnNIEaqn/APmw+bVLF2gAW7HIsdTxd12s5wQMqEpqIQrmrbRRZ0xC7g=="
+			"version": "6.3.0",
+			"resolved": "https://registry.npmjs.org/@turf/helpers/-/helpers-6.3.0.tgz",
+			"integrity": "sha512-kr6KuD4Z0GZ30tblTEvi90rvvVNlKieXuMC8CTzE/rVQb0/f/Cb29zCXxTD7giQTEQY/P2nRW23wEqqyNHulCg=="
 		},
 		"node_modules/@turf/intersect": {
 			"version": "6.1.3",
@@ -3960,11 +3962,11 @@
 			}
 		},
 		"node_modules/@turf/invariant": {
-			"version": "6.1.2",
-			"resolved": "https://registry.npmjs.org/@turf/invariant/-/invariant-6.1.2.tgz",
-			"integrity": "sha512-WU08Ph8j0J2jVGlQCKChXoCtI50BB3yEH21V++V0T4cR1T27HKCxkehV2sYMwTierfMBgjwSwDIsxnR4/2mWXg==",
+			"version": "6.3.0",
+			"resolved": "https://registry.npmjs.org/@turf/invariant/-/invariant-6.3.0.tgz",
+			"integrity": "sha512-2OFOi9p+QOrcIMySEnr+WlOiKaFZ1bY56jA98YyECewJHfhPFWUBZEhc4nWGRT0ahK08Vus9+gcuBX8QIpCIIw==",
 			"dependencies": {
-				"@turf/helpers": "6.x"
+				"@turf/helpers": "^6.3.0"
 			}
 		},
 		"node_modules/@turf/length": {
@@ -4015,11 +4017,11 @@
 			}
 		},
 		"node_modules/@turf/meta": {
-			"version": "6.0.2",
-			"resolved": "https://registry.npmjs.org/@turf/meta/-/meta-6.0.2.tgz",
-			"integrity": "sha512-VA7HJkx7qF1l3+GNGkDVn2oXy4+QoLP6LktXAaZKjuT1JI0YESat7quUkbCMy4zP9lAUuvS4YMslLyTtr919FA==",
+			"version": "6.3.0",
+			"resolved": "https://registry.npmjs.org/@turf/meta/-/meta-6.3.0.tgz",
+			"integrity": "sha512-qBJjaAJS9H3ap0HlGXyF/Bzfl0qkA9suafX/jnDsZvWMfVLt+s+o6twKrXOGk5t7nnNON2NFRC8+czxpu104EQ==",
 			"dependencies": {
-				"@turf/helpers": "6.x"
+				"@turf/helpers": "^6.3.0"
 			}
 		},
 		"node_modules/@turf/nearest-point-on-line": {
@@ -12466,16 +12468,12 @@
 		},
 		"node_modules/fsevents/node_modules/abbrev": {
 			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
-			"integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
 			"inBundle": true,
 			"license": "ISC",
 			"optional": true
 		},
 		"node_modules/fsevents/node_modules/ansi-regex": {
 			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-			"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
 			"inBundle": true,
 			"license": "MIT",
 			"optional": true,
@@ -12485,16 +12483,12 @@
 		},
 		"node_modules/fsevents/node_modules/aproba": {
 			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
-			"integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
 			"inBundle": true,
 			"license": "ISC",
 			"optional": true
 		},
 		"node_modules/fsevents/node_modules/are-we-there-yet": {
 			"version": "1.1.5",
-			"resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.5.tgz",
-			"integrity": "sha512-5hYdAkZlcG8tOLujVDTgCT+uPX0VnpAH28gWsLfzpXYm7wP6mp5Q/gYyR7YQ0cKVJcXJnl3j2kpBan13PtQf6w==",
 			"inBundle": true,
 			"license": "ISC",
 			"optional": true,
@@ -12505,16 +12499,12 @@
 		},
 		"node_modules/fsevents/node_modules/balanced-match": {
 			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-			"integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
 			"inBundle": true,
 			"license": "MIT",
 			"optional": true
 		},
 		"node_modules/fsevents/node_modules/brace-expansion": {
 			"version": "1.1.11",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-			"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
 			"inBundle": true,
 			"license": "MIT",
 			"optional": true,
@@ -12525,16 +12515,12 @@
 		},
 		"node_modules/fsevents/node_modules/chownr": {
 			"version": "1.1.4",
-			"resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
-			"integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
 			"inBundle": true,
 			"license": "ISC",
 			"optional": true
 		},
 		"node_modules/fsevents/node_modules/code-point-at": {
 			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-			"integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
 			"inBundle": true,
 			"license": "MIT",
 			"optional": true,
@@ -12544,32 +12530,24 @@
 		},
 		"node_modules/fsevents/node_modules/concat-map": {
 			"version": "0.0.1",
-			"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-			"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
 			"inBundle": true,
 			"license": "MIT",
 			"optional": true
 		},
 		"node_modules/fsevents/node_modules/console-control-strings": {
 			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
-			"integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
 			"inBundle": true,
 			"license": "ISC",
 			"optional": true
 		},
 		"node_modules/fsevents/node_modules/core-util-is": {
 			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-			"integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
 			"inBundle": true,
 			"license": "MIT",
 			"optional": true
 		},
 		"node_modules/fsevents/node_modules/debug": {
 			"version": "3.2.6",
-			"resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
-			"integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
 			"inBundle": true,
 			"license": "MIT",
 			"optional": true,
@@ -12579,8 +12557,6 @@
 		},
 		"node_modules/fsevents/node_modules/deep-extend": {
 			"version": "0.6.0",
-			"resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
-			"integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
 			"inBundle": true,
 			"license": "MIT",
 			"optional": true,
@@ -12590,16 +12566,12 @@
 		},
 		"node_modules/fsevents/node_modules/delegates": {
 			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
-			"integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
 			"inBundle": true,
 			"license": "MIT",
 			"optional": true
 		},
 		"node_modules/fsevents/node_modules/detect-libc": {
 			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
-			"integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=",
 			"inBundle": true,
 			"license": "Apache-2.0",
 			"optional": true,
@@ -12612,8 +12584,6 @@
 		},
 		"node_modules/fsevents/node_modules/fs-minipass": {
 			"version": "1.2.7",
-			"resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-1.2.7.tgz",
-			"integrity": "sha512-GWSSJGFy4e9GUeCcbIkED+bgAoFyj7XF1mV8rma3QW4NIqX9Kyx79N/PF61H5udOV3aY1IaMLs6pGbH71nlCTA==",
 			"inBundle": true,
 			"license": "ISC",
 			"optional": true,
@@ -12623,16 +12593,12 @@
 		},
 		"node_modules/fsevents/node_modules/fs.realpath": {
 			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-			"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
 			"inBundle": true,
 			"license": "ISC",
 			"optional": true
 		},
 		"node_modules/fsevents/node_modules/gauge": {
 			"version": "2.7.4",
-			"resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
-			"integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
 			"inBundle": true,
 			"license": "ISC",
 			"optional": true,
@@ -12649,8 +12615,6 @@
 		},
 		"node_modules/fsevents/node_modules/glob": {
 			"version": "7.1.6",
-			"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
-			"integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
 			"inBundle": true,
 			"license": "ISC",
 			"optional": true,
@@ -12671,16 +12635,12 @@
 		},
 		"node_modules/fsevents/node_modules/has-unicode": {
 			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
-			"integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
 			"inBundle": true,
 			"license": "ISC",
 			"optional": true
 		},
 		"node_modules/fsevents/node_modules/iconv-lite": {
 			"version": "0.4.24",
-			"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
-			"integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
 			"inBundle": true,
 			"license": "MIT",
 			"optional": true,
@@ -12693,8 +12653,6 @@
 		},
 		"node_modules/fsevents/node_modules/ignore-walk": {
 			"version": "3.0.3",
-			"resolved": "https://registry.npmjs.org/ignore-walk/-/ignore-walk-3.0.3.tgz",
-			"integrity": "sha512-m7o6xuOaT1aqheYHKf8W6J5pYH85ZI9w077erOzLje3JsB1gkafkAhHHY19dqjulgIZHFm32Cp5uNZgcQqdJKw==",
 			"inBundle": true,
 			"license": "ISC",
 			"optional": true,
@@ -12704,8 +12662,6 @@
 		},
 		"node_modules/fsevents/node_modules/inflight": {
 			"version": "1.0.6",
-			"resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-			"integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
 			"inBundle": true,
 			"license": "ISC",
 			"optional": true,
@@ -12716,16 +12672,12 @@
 		},
 		"node_modules/fsevents/node_modules/inherits": {
 			"version": "2.0.4",
-			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-			"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
 			"inBundle": true,
 			"license": "ISC",
 			"optional": true
 		},
 		"node_modules/fsevents/node_modules/ini": {
 			"version": "1.3.5",
-			"resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
-			"integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
 			"inBundle": true,
 			"license": "ISC",
 			"optional": true,
@@ -12735,8 +12687,6 @@
 		},
 		"node_modules/fsevents/node_modules/is-fullwidth-code-point": {
 			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-			"integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
 			"inBundle": true,
 			"license": "MIT",
 			"optional": true,
@@ -12749,16 +12699,12 @@
 		},
 		"node_modules/fsevents/node_modules/isarray": {
 			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-			"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
 			"inBundle": true,
 			"license": "MIT",
 			"optional": true
 		},
 		"node_modules/fsevents/node_modules/minimatch": {
 			"version": "3.0.4",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-			"integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
 			"inBundle": true,
 			"license": "ISC",
 			"optional": true,
@@ -12771,16 +12717,12 @@
 		},
 		"node_modules/fsevents/node_modules/minimist": {
 			"version": "1.2.5",
-			"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-			"integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
 			"inBundle": true,
 			"license": "MIT",
 			"optional": true
 		},
 		"node_modules/fsevents/node_modules/minipass": {
 			"version": "2.9.0",
-			"resolved": "https://registry.npmjs.org/minipass/-/minipass-2.9.0.tgz",
-			"integrity": "sha512-wxfUjg9WebH+CUDX/CdbRlh5SmfZiy/hpkxaRI16Y9W56Pa75sWgd/rvFilSgrauD9NyFymP/+JFV3KwzIsJeg==",
 			"inBundle": true,
 			"license": "ISC",
 			"optional": true,
@@ -12791,8 +12733,6 @@
 		},
 		"node_modules/fsevents/node_modules/minizlib": {
 			"version": "1.3.3",
-			"resolved": "https://registry.npmjs.org/minizlib/-/minizlib-1.3.3.tgz",
-			"integrity": "sha512-6ZYMOEnmVsdCeTJVE0W9ZD+pVnE8h9Hma/iOwwRDsdQoePpoX56/8B6z3P9VNwppJuBKNRuFDRNRqRWexT9G9Q==",
 			"inBundle": true,
 			"license": "MIT",
 			"optional": true,
@@ -12802,8 +12742,6 @@
 		},
 		"node_modules/fsevents/node_modules/mkdirp": {
 			"version": "0.5.3",
-			"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.3.tgz",
-			"integrity": "sha512-P+2gwrFqx8lhew375MQHHeTlY8AuOJSrGf0R5ddkEndUkmwpgUob/vQuBD1V22/Cw1/lJr4x+EjllSezBThzBg==",
 			"deprecated": "Legacy versions of mkdirp are no longer supported. Please update to mkdirp 1.x. (Note that the API surface has changed to use Promises in 1.x.)",
 			"inBundle": true,
 			"license": "MIT",
@@ -12817,16 +12755,12 @@
 		},
 		"node_modules/fsevents/node_modules/ms": {
 			"version": "2.1.2",
-			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-			"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
 			"inBundle": true,
 			"license": "MIT",
 			"optional": true
 		},
 		"node_modules/fsevents/node_modules/needle": {
 			"version": "2.3.3",
-			"resolved": "https://registry.npmjs.org/needle/-/needle-2.3.3.tgz",
-			"integrity": "sha512-EkY0GeSq87rWp1hoq/sH/wnTWgFVhYlnIkbJ0YJFfRgEFlz2RraCjBpFQ+vrEgEdp0ThfyHADmkChEhcb7PKyw==",
 			"inBundle": true,
 			"license": "MIT",
 			"optional": true,
@@ -12844,8 +12778,6 @@
 		},
 		"node_modules/fsevents/node_modules/node-pre-gyp": {
 			"version": "0.14.0",
-			"resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.14.0.tgz",
-			"integrity": "sha512-+CvDC7ZttU/sSt9rFjix/P05iS43qHCOOGzcr3Ry99bXG7VX953+vFyEuph/tfqoYu8dttBkE86JSKBO2OzcxA==",
 			"inBundle": true,
 			"license": "BSD-3-Clause",
 			"optional": true,
@@ -12867,8 +12799,6 @@
 		},
 		"node_modules/fsevents/node_modules/nopt": {
 			"version": "4.0.3",
-			"resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.3.tgz",
-			"integrity": "sha512-CvaGwVMztSMJLOeXPrez7fyfObdZqNUK1cPAEzLHrTybIua9pMdmmPR5YwtfNftIOMv3DPUhFaxsZMNTQO20Kg==",
 			"inBundle": true,
 			"license": "ISC",
 			"optional": true,
@@ -12882,8 +12812,6 @@
 		},
 		"node_modules/fsevents/node_modules/npm-bundled": {
 			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/npm-bundled/-/npm-bundled-1.1.1.tgz",
-			"integrity": "sha512-gqkfgGePhTpAEgUsGEgcq1rqPXA+tv/aVBlgEzfXwA1yiUJF7xtEt3CtVwOjNYQOVknDk0F20w58Fnm3EtG0fA==",
 			"inBundle": true,
 			"license": "ISC",
 			"optional": true,
@@ -12893,16 +12821,12 @@
 		},
 		"node_modules/fsevents/node_modules/npm-normalize-package-bin": {
 			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/npm-normalize-package-bin/-/npm-normalize-package-bin-1.0.1.tgz",
-			"integrity": "sha512-EPfafl6JL5/rU+ot6P3gRSCpPDW5VmIzX959Ob1+ySFUuuYHWHekXpwdUZcKP5C+DS4GEtdJluwBjnsNDl+fSA==",
 			"inBundle": true,
 			"license": "ISC",
 			"optional": true
 		},
 		"node_modules/fsevents/node_modules/npm-packlist": {
 			"version": "1.4.8",
-			"resolved": "https://registry.npmjs.org/npm-packlist/-/npm-packlist-1.4.8.tgz",
-			"integrity": "sha512-5+AZgwru5IevF5ZdnFglB5wNlHG1AOOuw28WhUq8/8emhBmLv6jX5by4WJCh7lW0uSYZYS6DXqIsyZVIXRZU9A==",
 			"inBundle": true,
 			"license": "ISC",
 			"optional": true,
@@ -12914,8 +12838,6 @@
 		},
 		"node_modules/fsevents/node_modules/npmlog": {
 			"version": "4.1.2",
-			"resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
-			"integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
 			"inBundle": true,
 			"license": "ISC",
 			"optional": true,
@@ -12928,8 +12850,6 @@
 		},
 		"node_modules/fsevents/node_modules/number-is-nan": {
 			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-			"integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
 			"inBundle": true,
 			"license": "MIT",
 			"optional": true,
@@ -12939,8 +12859,6 @@
 		},
 		"node_modules/fsevents/node_modules/object-assign": {
 			"version": "4.1.1",
-			"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-			"integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
 			"inBundle": true,
 			"license": "MIT",
 			"optional": true,
@@ -12950,8 +12868,6 @@
 		},
 		"node_modules/fsevents/node_modules/once": {
 			"version": "1.4.0",
-			"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-			"integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
 			"inBundle": true,
 			"license": "ISC",
 			"optional": true,
@@ -12961,8 +12877,6 @@
 		},
 		"node_modules/fsevents/node_modules/os-homedir": {
 			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
-			"integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
 			"inBundle": true,
 			"license": "MIT",
 			"optional": true,
@@ -12972,8 +12886,6 @@
 		},
 		"node_modules/fsevents/node_modules/os-tmpdir": {
 			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
-			"integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
 			"inBundle": true,
 			"license": "MIT",
 			"optional": true,
@@ -12983,8 +12895,6 @@
 		},
 		"node_modules/fsevents/node_modules/osenv": {
 			"version": "0.1.5",
-			"resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.5.tgz",
-			"integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
 			"inBundle": true,
 			"license": "ISC",
 			"optional": true,
@@ -12995,8 +12905,6 @@
 		},
 		"node_modules/fsevents/node_modules/path-is-absolute": {
 			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-			"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
 			"inBundle": true,
 			"license": "MIT",
 			"optional": true,
@@ -13006,16 +12914,12 @@
 		},
 		"node_modules/fsevents/node_modules/process-nextick-args": {
 			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
-			"integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
 			"inBundle": true,
 			"license": "MIT",
 			"optional": true
 		},
 		"node_modules/fsevents/node_modules/rc": {
 			"version": "1.2.8",
-			"resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
-			"integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
 			"inBundle": true,
 			"license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
 			"optional": true,
@@ -13031,8 +12935,6 @@
 		},
 		"node_modules/fsevents/node_modules/readable-stream": {
 			"version": "2.3.7",
-			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
-			"integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
 			"inBundle": true,
 			"license": "MIT",
 			"optional": true,
@@ -13048,8 +12950,6 @@
 		},
 		"node_modules/fsevents/node_modules/rimraf": {
 			"version": "2.7.1",
-			"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
-			"integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
 			"inBundle": true,
 			"license": "ISC",
 			"optional": true,
@@ -13062,32 +12962,24 @@
 		},
 		"node_modules/fsevents/node_modules/safe-buffer": {
 			"version": "5.1.2",
-			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-			"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
 			"inBundle": true,
 			"license": "MIT",
 			"optional": true
 		},
 		"node_modules/fsevents/node_modules/safer-buffer": {
 			"version": "2.1.2",
-			"resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-			"integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
 			"inBundle": true,
 			"license": "MIT",
 			"optional": true
 		},
 		"node_modules/fsevents/node_modules/sax": {
 			"version": "1.2.4",
-			"resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
-			"integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
 			"inBundle": true,
 			"license": "ISC",
 			"optional": true
 		},
 		"node_modules/fsevents/node_modules/semver": {
 			"version": "5.7.1",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-			"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
 			"inBundle": true,
 			"license": "ISC",
 			"optional": true,
@@ -13097,24 +12989,18 @@
 		},
 		"node_modules/fsevents/node_modules/set-blocking": {
 			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-			"integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
 			"inBundle": true,
 			"license": "ISC",
 			"optional": true
 		},
 		"node_modules/fsevents/node_modules/signal-exit": {
 			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
-			"integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
 			"inBundle": true,
 			"license": "ISC",
 			"optional": true
 		},
 		"node_modules/fsevents/node_modules/string_decoder": {
 			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-			"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
 			"inBundle": true,
 			"license": "MIT",
 			"optional": true,
@@ -13124,8 +13010,6 @@
 		},
 		"node_modules/fsevents/node_modules/string-width": {
 			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-			"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
 			"inBundle": true,
 			"license": "MIT",
 			"optional": true,
@@ -13140,8 +13024,6 @@
 		},
 		"node_modules/fsevents/node_modules/strip-ansi": {
 			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-			"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
 			"inBundle": true,
 			"license": "MIT",
 			"optional": true,
@@ -13154,8 +13036,6 @@
 		},
 		"node_modules/fsevents/node_modules/strip-json-comments": {
 			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-			"integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
 			"inBundle": true,
 			"license": "MIT",
 			"optional": true,
@@ -13165,8 +13045,6 @@
 		},
 		"node_modules/fsevents/node_modules/tar": {
 			"version": "4.4.13",
-			"resolved": "https://registry.npmjs.org/tar/-/tar-4.4.13.tgz",
-			"integrity": "sha512-w2VwSrBoHa5BsSyH+KxEqeQBAllHhccyMFVHtGtdMpF4W7IRWfZjFiQceJPChOeTsSDVUpER2T8FA93pr0L+QA==",
 			"inBundle": true,
 			"license": "ISC",
 			"optional": true,
@@ -13185,16 +13063,12 @@
 		},
 		"node_modules/fsevents/node_modules/util-deprecate": {
 			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-			"integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
 			"inBundle": true,
 			"license": "MIT",
 			"optional": true
 		},
 		"node_modules/fsevents/node_modules/wide-align": {
 			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.3.tgz",
-			"integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
 			"inBundle": true,
 			"license": "ISC",
 			"optional": true,
@@ -13204,16 +13078,12 @@
 		},
 		"node_modules/fsevents/node_modules/wrappy": {
 			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-			"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
 			"inBundle": true,
 			"license": "ISC",
 			"optional": true
 		},
 		"node_modules/fsevents/node_modules/yallist": {
 			"version": "3.1.1",
-			"resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
-			"integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
 			"inBundle": true,
 			"license": "ISC",
 			"optional": true
@@ -28329,12 +28199,12 @@
 			}
 		},
 		"@turf/distance": {
-			"version": "6.0.1",
-			"resolved": "https://registry.npmjs.org/@turf/distance/-/distance-6.0.1.tgz",
-			"integrity": "sha512-q7t7rWIWfkg7MP1Vt4uLjSEhe5rPfCO2JjpKmk7JC+QZKEQkuvHEqy3ejW1iC7Kw5ZcZNR3qdMGGz+6HnVwqvg==",
+			"version": "6.3.0",
+			"resolved": "https://registry.npmjs.org/@turf/distance/-/distance-6.3.0.tgz",
+			"integrity": "sha512-basi24ssNFnH3iXPFjp/aNUrukjObiFWoIyDRqKyBJxVwVOwAWvfk4d38QQyBj5nDo5IahYRq/Q+T47/5hSs9w==",
 			"requires": {
-				"@turf/helpers": "6.x",
-				"@turf/invariant": "6.x"
+				"@turf/helpers": "^6.3.0",
+				"@turf/invariant": "^6.3.0"
 			}
 		},
 		"@turf/flatten": {
@@ -28362,9 +28232,9 @@
 			}
 		},
 		"@turf/helpers": {
-			"version": "6.1.4",
-			"resolved": "https://registry.npmjs.org/@turf/helpers/-/helpers-6.1.4.tgz",
-			"integrity": "sha512-vJvrdOZy1ngC7r3MDA7zIGSoIgyrkWcGnNIEaqn/APmw+bVLF2gAW7HIsdTxd12s5wQMqEpqIQrmrbRRZ0xC7g=="
+			"version": "6.3.0",
+			"resolved": "https://registry.npmjs.org/@turf/helpers/-/helpers-6.3.0.tgz",
+			"integrity": "sha512-kr6KuD4Z0GZ30tblTEvi90rvvVNlKieXuMC8CTzE/rVQb0/f/Cb29zCXxTD7giQTEQY/P2nRW23wEqqyNHulCg=="
 		},
 		"@turf/intersect": {
 			"version": "6.1.3",
@@ -28388,11 +28258,11 @@
 			}
 		},
 		"@turf/invariant": {
-			"version": "6.1.2",
-			"resolved": "https://registry.npmjs.org/@turf/invariant/-/invariant-6.1.2.tgz",
-			"integrity": "sha512-WU08Ph8j0J2jVGlQCKChXoCtI50BB3yEH21V++V0T4cR1T27HKCxkehV2sYMwTierfMBgjwSwDIsxnR4/2mWXg==",
+			"version": "6.3.0",
+			"resolved": "https://registry.npmjs.org/@turf/invariant/-/invariant-6.3.0.tgz",
+			"integrity": "sha512-2OFOi9p+QOrcIMySEnr+WlOiKaFZ1bY56jA98YyECewJHfhPFWUBZEhc4nWGRT0ahK08Vus9+gcuBX8QIpCIIw==",
 			"requires": {
-				"@turf/helpers": "6.x"
+				"@turf/helpers": "^6.3.0"
 			}
 		},
 		"@turf/length": {
@@ -28443,11 +28313,11 @@
 			}
 		},
 		"@turf/meta": {
-			"version": "6.0.2",
-			"resolved": "https://registry.npmjs.org/@turf/meta/-/meta-6.0.2.tgz",
-			"integrity": "sha512-VA7HJkx7qF1l3+GNGkDVn2oXy4+QoLP6LktXAaZKjuT1JI0YESat7quUkbCMy4zP9lAUuvS4YMslLyTtr919FA==",
+			"version": "6.3.0",
+			"resolved": "https://registry.npmjs.org/@turf/meta/-/meta-6.3.0.tgz",
+			"integrity": "sha512-qBJjaAJS9H3ap0HlGXyF/Bzfl0qkA9suafX/jnDsZvWMfVLt+s+o6twKrXOGk5t7nnNON2NFRC8+czxpu104EQ==",
 			"requires": {
-				"@turf/helpers": "6.x"
+				"@turf/helpers": "^6.3.0"
 			}
 		},
 		"@turf/nearest-point-on-line": {
@@ -35668,29 +35538,21 @@
 			"dependencies": {
 				"abbrev": {
 					"version": "1.1.1",
-					"resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
-					"integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
 					"bundled": true,
 					"optional": true
 				},
 				"ansi-regex": {
 					"version": "2.1.1",
-					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-					"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
 					"bundled": true,
 					"optional": true
 				},
 				"aproba": {
 					"version": "1.2.0",
-					"resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
-					"integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
 					"bundled": true,
 					"optional": true
 				},
 				"are-we-there-yet": {
 					"version": "1.1.5",
-					"resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.5.tgz",
-					"integrity": "sha512-5hYdAkZlcG8tOLujVDTgCT+uPX0VnpAH28gWsLfzpXYm7wP6mp5Q/gYyR7YQ0cKVJcXJnl3j2kpBan13PtQf6w==",
 					"bundled": true,
 					"optional": true,
 					"requires": {
@@ -35700,15 +35562,11 @@
 				},
 				"balanced-match": {
 					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-					"integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
 					"bundled": true,
 					"optional": true
 				},
 				"brace-expansion": {
 					"version": "1.1.11",
-					"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-					"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
 					"bundled": true,
 					"optional": true,
 					"requires": {
@@ -35718,43 +35576,31 @@
 				},
 				"chownr": {
 					"version": "1.1.4",
-					"resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
-					"integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
 					"bundled": true,
 					"optional": true
 				},
 				"code-point-at": {
 					"version": "1.1.0",
-					"resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-					"integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
 					"bundled": true,
 					"optional": true
 				},
 				"concat-map": {
 					"version": "0.0.1",
-					"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-					"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
 					"bundled": true,
 					"optional": true
 				},
 				"console-control-strings": {
 					"version": "1.1.0",
-					"resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
-					"integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
 					"bundled": true,
 					"optional": true
 				},
 				"core-util-is": {
 					"version": "1.0.2",
-					"resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-					"integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
 					"bundled": true,
 					"optional": true
 				},
 				"debug": {
 					"version": "3.2.6",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
-					"integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
 					"bundled": true,
 					"optional": true,
 					"requires": {
@@ -35763,29 +35609,21 @@
 				},
 				"deep-extend": {
 					"version": "0.6.0",
-					"resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
-					"integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
 					"bundled": true,
 					"optional": true
 				},
 				"delegates": {
 					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
-					"integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
 					"bundled": true,
 					"optional": true
 				},
 				"detect-libc": {
 					"version": "1.0.3",
-					"resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
-					"integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=",
 					"bundled": true,
 					"optional": true
 				},
 				"fs-minipass": {
 					"version": "1.2.7",
-					"resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-1.2.7.tgz",
-					"integrity": "sha512-GWSSJGFy4e9GUeCcbIkED+bgAoFyj7XF1mV8rma3QW4NIqX9Kyx79N/PF61H5udOV3aY1IaMLs6pGbH71nlCTA==",
 					"bundled": true,
 					"optional": true,
 					"requires": {
@@ -35794,15 +35632,11 @@
 				},
 				"fs.realpath": {
 					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-					"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
 					"bundled": true,
 					"optional": true
 				},
 				"gauge": {
 					"version": "2.7.4",
-					"resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
-					"integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
 					"bundled": true,
 					"optional": true,
 					"requires": {
@@ -35818,8 +35652,6 @@
 				},
 				"glob": {
 					"version": "7.1.6",
-					"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
-					"integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
 					"bundled": true,
 					"optional": true,
 					"requires": {
@@ -35833,15 +35665,11 @@
 				},
 				"has-unicode": {
 					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
-					"integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
 					"bundled": true,
 					"optional": true
 				},
 				"iconv-lite": {
 					"version": "0.4.24",
-					"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
-					"integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
 					"bundled": true,
 					"optional": true,
 					"requires": {
@@ -35850,8 +35678,6 @@
 				},
 				"ignore-walk": {
 					"version": "3.0.3",
-					"resolved": "https://registry.npmjs.org/ignore-walk/-/ignore-walk-3.0.3.tgz",
-					"integrity": "sha512-m7o6xuOaT1aqheYHKf8W6J5pYH85ZI9w077erOzLje3JsB1gkafkAhHHY19dqjulgIZHFm32Cp5uNZgcQqdJKw==",
 					"bundled": true,
 					"optional": true,
 					"requires": {
@@ -35860,8 +35686,6 @@
 				},
 				"inflight": {
 					"version": "1.0.6",
-					"resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-					"integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
 					"bundled": true,
 					"optional": true,
 					"requires": {
@@ -35871,22 +35695,16 @@
 				},
 				"inherits": {
 					"version": "2.0.4",
-					"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-					"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
 					"bundled": true,
 					"optional": true
 				},
 				"ini": {
 					"version": "1.3.5",
-					"resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
-					"integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
 					"bundled": true,
 					"optional": true
 				},
 				"is-fullwidth-code-point": {
 					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-					"integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
 					"bundled": true,
 					"optional": true,
 					"requires": {
@@ -35895,15 +35713,11 @@
 				},
 				"isarray": {
 					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-					"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
 					"bundled": true,
 					"optional": true
 				},
 				"minimatch": {
 					"version": "3.0.4",
-					"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-					"integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
 					"bundled": true,
 					"optional": true,
 					"requires": {
@@ -35912,15 +35726,11 @@
 				},
 				"minimist": {
 					"version": "1.2.5",
-					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-					"integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
 					"bundled": true,
 					"optional": true
 				},
 				"minipass": {
 					"version": "2.9.0",
-					"resolved": "https://registry.npmjs.org/minipass/-/minipass-2.9.0.tgz",
-					"integrity": "sha512-wxfUjg9WebH+CUDX/CdbRlh5SmfZiy/hpkxaRI16Y9W56Pa75sWgd/rvFilSgrauD9NyFymP/+JFV3KwzIsJeg==",
 					"bundled": true,
 					"optional": true,
 					"requires": {
@@ -35930,8 +35740,6 @@
 				},
 				"minizlib": {
 					"version": "1.3.3",
-					"resolved": "https://registry.npmjs.org/minizlib/-/minizlib-1.3.3.tgz",
-					"integrity": "sha512-6ZYMOEnmVsdCeTJVE0W9ZD+pVnE8h9Hma/iOwwRDsdQoePpoX56/8B6z3P9VNwppJuBKNRuFDRNRqRWexT9G9Q==",
 					"bundled": true,
 					"optional": true,
 					"requires": {
@@ -35940,8 +35748,6 @@
 				},
 				"mkdirp": {
 					"version": "0.5.3",
-					"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.3.tgz",
-					"integrity": "sha512-P+2gwrFqx8lhew375MQHHeTlY8AuOJSrGf0R5ddkEndUkmwpgUob/vQuBD1V22/Cw1/lJr4x+EjllSezBThzBg==",
 					"bundled": true,
 					"optional": true,
 					"requires": {
@@ -35950,15 +35756,11 @@
 				},
 				"ms": {
 					"version": "2.1.2",
-					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-					"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
 					"bundled": true,
 					"optional": true
 				},
 				"needle": {
 					"version": "2.3.3",
-					"resolved": "https://registry.npmjs.org/needle/-/needle-2.3.3.tgz",
-					"integrity": "sha512-EkY0GeSq87rWp1hoq/sH/wnTWgFVhYlnIkbJ0YJFfRgEFlz2RraCjBpFQ+vrEgEdp0ThfyHADmkChEhcb7PKyw==",
 					"bundled": true,
 					"optional": true,
 					"requires": {
@@ -35969,8 +35771,6 @@
 				},
 				"node-pre-gyp": {
 					"version": "0.14.0",
-					"resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.14.0.tgz",
-					"integrity": "sha512-+CvDC7ZttU/sSt9rFjix/P05iS43qHCOOGzcr3Ry99bXG7VX953+vFyEuph/tfqoYu8dttBkE86JSKBO2OzcxA==",
 					"bundled": true,
 					"optional": true,
 					"requires": {
@@ -35988,8 +35788,6 @@
 				},
 				"nopt": {
 					"version": "4.0.3",
-					"resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.3.tgz",
-					"integrity": "sha512-CvaGwVMztSMJLOeXPrez7fyfObdZqNUK1cPAEzLHrTybIua9pMdmmPR5YwtfNftIOMv3DPUhFaxsZMNTQO20Kg==",
 					"bundled": true,
 					"optional": true,
 					"requires": {
@@ -35999,8 +35797,6 @@
 				},
 				"npm-bundled": {
 					"version": "1.1.1",
-					"resolved": "https://registry.npmjs.org/npm-bundled/-/npm-bundled-1.1.1.tgz",
-					"integrity": "sha512-gqkfgGePhTpAEgUsGEgcq1rqPXA+tv/aVBlgEzfXwA1yiUJF7xtEt3CtVwOjNYQOVknDk0F20w58Fnm3EtG0fA==",
 					"bundled": true,
 					"optional": true,
 					"requires": {
@@ -36009,15 +35805,11 @@
 				},
 				"npm-normalize-package-bin": {
 					"version": "1.0.1",
-					"resolved": "https://registry.npmjs.org/npm-normalize-package-bin/-/npm-normalize-package-bin-1.0.1.tgz",
-					"integrity": "sha512-EPfafl6JL5/rU+ot6P3gRSCpPDW5VmIzX959Ob1+ySFUuuYHWHekXpwdUZcKP5C+DS4GEtdJluwBjnsNDl+fSA==",
 					"bundled": true,
 					"optional": true
 				},
 				"npm-packlist": {
 					"version": "1.4.8",
-					"resolved": "https://registry.npmjs.org/npm-packlist/-/npm-packlist-1.4.8.tgz",
-					"integrity": "sha512-5+AZgwru5IevF5ZdnFglB5wNlHG1AOOuw28WhUq8/8emhBmLv6jX5by4WJCh7lW0uSYZYS6DXqIsyZVIXRZU9A==",
 					"bundled": true,
 					"optional": true,
 					"requires": {
@@ -36028,8 +35820,6 @@
 				},
 				"npmlog": {
 					"version": "4.1.2",
-					"resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
-					"integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
 					"bundled": true,
 					"optional": true,
 					"requires": {
@@ -36041,22 +35831,16 @@
 				},
 				"number-is-nan": {
 					"version": "1.0.1",
-					"resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-					"integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
 					"bundled": true,
 					"optional": true
 				},
 				"object-assign": {
 					"version": "4.1.1",
-					"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-					"integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
 					"bundled": true,
 					"optional": true
 				},
 				"once": {
 					"version": "1.4.0",
-					"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-					"integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
 					"bundled": true,
 					"optional": true,
 					"requires": {
@@ -36065,22 +35849,16 @@
 				},
 				"os-homedir": {
 					"version": "1.0.2",
-					"resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
-					"integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
 					"bundled": true,
 					"optional": true
 				},
 				"os-tmpdir": {
 					"version": "1.0.2",
-					"resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
-					"integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
 					"bundled": true,
 					"optional": true
 				},
 				"osenv": {
 					"version": "0.1.5",
-					"resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.5.tgz",
-					"integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
 					"bundled": true,
 					"optional": true,
 					"requires": {
@@ -36090,22 +35868,16 @@
 				},
 				"path-is-absolute": {
 					"version": "1.0.1",
-					"resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-					"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
 					"bundled": true,
 					"optional": true
 				},
 				"process-nextick-args": {
 					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
-					"integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
 					"bundled": true,
 					"optional": true
 				},
 				"rc": {
 					"version": "1.2.8",
-					"resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
-					"integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
 					"bundled": true,
 					"optional": true,
 					"requires": {
@@ -36117,8 +35889,6 @@
 				},
 				"readable-stream": {
 					"version": "2.3.7",
-					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
-					"integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
 					"bundled": true,
 					"optional": true,
 					"requires": {
@@ -36133,8 +35903,6 @@
 				},
 				"rimraf": {
 					"version": "2.7.1",
-					"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
-					"integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
 					"bundled": true,
 					"optional": true,
 					"requires": {
@@ -36143,50 +35911,36 @@
 				},
 				"safe-buffer": {
 					"version": "5.1.2",
-					"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-					"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
 					"bundled": true,
 					"optional": true
 				},
 				"safer-buffer": {
 					"version": "2.1.2",
-					"resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-					"integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
 					"bundled": true,
 					"optional": true
 				},
 				"sax": {
 					"version": "1.2.4",
-					"resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
-					"integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
 					"bundled": true,
 					"optional": true
 				},
 				"semver": {
 					"version": "5.7.1",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-					"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
 					"bundled": true,
 					"optional": true
 				},
 				"set-blocking": {
 					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-					"integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
 					"bundled": true,
 					"optional": true
 				},
 				"signal-exit": {
 					"version": "3.0.2",
-					"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
-					"integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
 					"bundled": true,
 					"optional": true
 				},
 				"string_decoder": {
 					"version": "1.1.1",
-					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-					"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
 					"bundled": true,
 					"optional": true,
 					"requires": {
@@ -36195,8 +35949,6 @@
 				},
 				"string-width": {
 					"version": "1.0.2",
-					"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-					"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
 					"bundled": true,
 					"optional": true,
 					"requires": {
@@ -36207,8 +35959,6 @@
 				},
 				"strip-ansi": {
 					"version": "3.0.1",
-					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-					"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
 					"bundled": true,
 					"optional": true,
 					"requires": {
@@ -36217,15 +35967,11 @@
 				},
 				"strip-json-comments": {
 					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-					"integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
 					"bundled": true,
 					"optional": true
 				},
 				"tar": {
 					"version": "4.4.13",
-					"resolved": "https://registry.npmjs.org/tar/-/tar-4.4.13.tgz",
-					"integrity": "sha512-w2VwSrBoHa5BsSyH+KxEqeQBAllHhccyMFVHtGtdMpF4W7IRWfZjFiQceJPChOeTsSDVUpER2T8FA93pr0L+QA==",
 					"bundled": true,
 					"optional": true,
 					"requires": {
@@ -36240,15 +35986,11 @@
 				},
 				"util-deprecate": {
 					"version": "1.0.2",
-					"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-					"integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
 					"bundled": true,
 					"optional": true
 				},
 				"wide-align": {
 					"version": "1.1.3",
-					"resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.3.tgz",
-					"integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
 					"bundled": true,
 					"optional": true,
 					"requires": {
@@ -36257,15 +35999,11 @@
 				},
 				"wrappy": {
 					"version": "1.0.2",
-					"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-					"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
 					"bundled": true,
 					"optional": true
 				},
 				"yallist": {
 					"version": "3.1.1",
-					"resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
-					"integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
 					"bundled": true,
 					"optional": true
 				}


### PR DESCRIPTION
This PR is meant to make it easier to do the basics with the framework locally and does a little cleanup:

* Removes unused root dependencies.  seemed to have been errantly added
* Document use of `npm install` at top-level to install lerna at root level, and a new postinstall script which then runs the bootstrap.  This simplifies and also avoids need to install lerna globally or use npx or know the right lerna incantantation.
* Add `publish` and `publish:alpha` scripts to root that simplifies setup steps and again avoids the need to know the right lerna commands or have lerna install globally (or via npx)
