### PR TITLE
ci: fix build and shed node 12.x

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,14 +14,17 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [12.x, 14.x, 16.x]
+        node-version: [14.x, 16.x]
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2
         with:
           node-version: ${{ matrix.node-version }}
+      - name: Node version
+        run: node -v
       - name: Upgrade npm
-        run: npm install -g npm@latest
+        run: npm install -g npm@7.10.0
+        run: npm -v
       - name: Install modules
         run: npm install
       - name: Run tests


### PR DESCRIPTION
ci: pin npm version due to lockfile inconsistent handling with newer 8.7.0, drop node 12.x