### PR TITLE
fix dynamodb bug with workaround

### DIFF
--- a/packages/geoprocessing/jest-dynamodb-config.js
+++ b/packages/geoprocessing/jest-dynamodb-config.js
@@ -1,4 +1,9 @@
 module.exports = {
+  // https://github.com/shelfio/jest-dynamodb/issues/212
+  installerConfig: {
+    downloadUrl:
+      "https://s3.eu-central-1.amazonaws.com/dynamodb-local-frankfurt/dynamodb_local_2023-06-09.tar.gz",
+  },
   tables: [
     {
       TableName: `tasks-core`,


### PR DESCRIPTION
https://stackoverflow.com/questions/76592141/aws-js-sdk-suddenly-throws-the-access-key-id-or-security-token-is-invalid