### PR TITLE
Add support for packing and unpacking metrics within TaskModel

### DIFF
--- a/packages/geoprocessing/src/aws/tasks.ts
+++ b/packages/geoprocessing/src/aws/tasks.ts
@@ -1,6 +1,13 @@
 import { v4 as uuid } from "uuid";
 import { APIGatewayProxyResult } from "aws-lambda";
 import { DynamoDB } from "aws-sdk";
+import {
+  isMetricArray,
+  isMetricPack,
+  packMetrics,
+  unpackMetrics,
+} from "../metrics";
+import cloneDeep from "lodash/cloneDeep";
 
 export const commonHeaders = {
   "Access-Control-Allow-Origin": "*",
@@ -131,6 +138,11 @@ export default class TasksModel {
     task.status = GeoprocessingTaskStatus.Completed;
     task.duration = new Date().getTime() - new Date(task.startedAt).getTime();
 
+    // Check for metrics and pack them before inserting into DB
+    const dataToStore = cloneDeep(results);
+    if (results.metrics && isMetricArray(results.metrics)) {
+      dataToStore.metrics = packMetrics(results.metrics);
+    }
     await this.db
       .update({
         TableName: this.table,
@@ -294,7 +306,17 @@ export default class TasksModel {
           },
         })
         .promise();
-      return response.Item as GeoprocessingTask;
+
+      const result = response.Item as GeoprocessingTask;
+      // Check for metrics and unpack them before returning
+      if (
+        result.data &&
+        result.data.metrics &&
+        isMetricPack(result.data.metrics)
+      ) {
+        result.data.metrics = unpackMetrics(result.data.metrics);
+      }
+      return result;
     } catch (e) {
       return undefined;
     }

--- a/packages/geoprocessing/src/metrics/helpers.test.ts
+++ b/packages/geoprocessing/src/metrics/helpers.test.ts
@@ -8,6 +8,8 @@ import {
   flattenBySketchAllClass,
   nestMetrics,
   createMetric,
+  packMetrics,
+  unpackMetrics,
 } from "./helpers";
 import { NullSketch, NullSketchCollection, Metric } from "../types";
 import { toPercentMetric } from "../../client-core";
@@ -261,6 +263,40 @@ const groupMetrics: Metric[] = [
     value: 15,
   }),
 ];
+
+describe("MetricPack", () => {
+  test("Can pack and unpack metrics", async () => {
+    const packed = packMetrics(metrics);
+    expect(packed.hasOwnProperty("dimensions")).toBe(true);
+    expect(packed.hasOwnProperty("data")).toBe(true);
+    expect(packed.dimensions).toHaveLength(6);
+    expect(packed.data).toHaveLength(8);
+    expect(packed.data[0]).toHaveLength(6);
+
+    const unpacked = unpackMetrics(packed);
+    expect(unpacked).toHaveLength(metrics.length);
+  });
+
+  test("Can pack and unpack metrics with extra", async () => {
+    const metrics = [
+      createMetric({
+        value: 15,
+        extra: { big: "fish" },
+      }),
+    ];
+    const packed = packMetrics(metrics);
+    expect(packed.hasOwnProperty("dimensions")).toBe(true);
+    expect(packed.hasOwnProperty("data")).toBe(true);
+    expect(packed.dimensions).toHaveLength(7);
+    expect(packed.data).toHaveLength(1);
+    expect(packed.data[0]).toHaveLength(7);
+
+    const unpacked = unpackMetrics(packed);
+    expect(unpacked).toHaveLength(metrics.length);
+    expect(unpacked[0].value).toEqual(15);
+    expect(unpacked[0]?.extra?.big).toEqual("fish");
+  });
+});
 
 describe("flattenSketchAllClass", () => {
   test("flattenSketchAllClass - basic", async () => {

--- a/packages/geoprocessing/src/metrics/helpers.test.ts
+++ b/packages/geoprocessing/src/metrics/helpers.test.ts
@@ -10,6 +10,8 @@ import {
   createMetric,
   packMetrics,
   unpackMetrics,
+  isMetric,
+  isMetricArray,
 } from "./helpers";
 import { NullSketch, NullSketchCollection, Metric } from "../types";
 import { toPercentMetric } from "../../client-core";
@@ -264,14 +266,35 @@ const groupMetrics: Metric[] = [
   }),
 ];
 
+describe("Metric checks", () => {
+  test("isMetric", async () => {
+    const trueMetric = metrics[0];
+    trueMetric.extra = { big: "fish" };
+    expect(isMetric(trueMetric)).toBe(true);
+  });
+
+  test("isMetric false", async () => {
+    const falseMetric = { value: 15 };
+    expect(isMetric(falseMetric)).toBe(false);
+    const falseMetric2 = createMetric({ value: 15 });
+    //@ts-ignore
+    falseMetric2.groupId = undefined; // not allowed
+    expect(isMetric(falseMetric2)).toBe(false);
+  });
+
+  test("isMetricArray", async () => {
+    expect(isMetricArray(metrics)).toBe(true);
+  });
+});
+
 describe("MetricPack", () => {
   test("Can pack and unpack metrics", async () => {
     const packed = packMetrics(metrics);
     expect(packed.hasOwnProperty("dimensions")).toBe(true);
     expect(packed.hasOwnProperty("data")).toBe(true);
-    expect(packed.dimensions).toHaveLength(6);
+    expect(packed.dimensions).toHaveLength(7);
     expect(packed.data).toHaveLength(8);
-    expect(packed.data[0]).toHaveLength(6);
+    expect(packed.data[0]).toHaveLength(7);
 
     const unpacked = unpackMetrics(packed);
     expect(unpacked).toHaveLength(metrics.length);

--- a/packages/geoprocessing/src/metrics/helpers.ts
+++ b/packages/geoprocessing/src/metrics/helpers.ts
@@ -10,6 +10,7 @@ import {
   DataClass,
   MetricIdTypes,
   GroupMetricSketchAgg,
+  MetricDimensions,
 } from "../types";
 
 import {
@@ -19,6 +20,7 @@ import {
   isSketchCollection,
   isNullSketch,
   isNullSketchCollection,
+  hasOwnProperty,
 } from "../helpers";
 
 import reduce from "lodash/reduce";
@@ -122,6 +124,48 @@ export const unpackMetrics = (metricPack: MetricPack): Metric[] => {
   }
 
   return metrics;
+};
+
+/**
+ * Checks if object is a MetricPack.  Any code inside a block guarded by a conditional call to this function will have type narrowed to MetricPack
+ */
+export const isMetricPack = (json: any): json is MetricPack => {
+  return (
+    json &&
+    hasOwnProperty(json, "dimensions") &&
+    Array.isArray(json.dimensions) &&
+    hasOwnProperty(json, "data") &&
+    Array.isArray(json.data)
+  );
+};
+
+/**
+ * Checks if object is a Metric array and returns narrowed type
+ */
+export const isMetricArray = (metrics: any): metrics is Metric[] => {
+  return (
+    metrics &&
+    Array.isArray(metrics) &&
+    metrics.length > 0 &&
+    isMetric(metrics[0])
+  );
+};
+
+/**
+ * Checks if object is a Metric and returns narrowed type
+ */
+export const isMetric = (metric: any): metric is Metric => {
+  return (
+    metric &&
+    MetricDimensions.reduce(
+      (soFar, curDim) =>
+        soFar &&
+        metric.hasOwnProperty(curDim) &&
+        (metric[curDim] === null || !!metric[curDim]),
+      true
+    ) &&
+    metric.hasOwnProperty("value")
+  );
 };
 
 /**

--- a/packages/geoprocessing/src/metrics/helpers.ts
+++ b/packages/geoprocessing/src/metrics/helpers.ts
@@ -4,6 +4,7 @@ import {
   NullSketch,
   NullSketchCollection,
   Metric,
+  MetricPack,
   MetricDimension,
   MetricProperty,
   DataClass,
@@ -73,6 +74,54 @@ export const rekeyMetrics = (
     });
     return newMetric;
   }) as Metric[];
+};
+
+/**
+ * Converts Metric array to a MetricPack.
+ * Assumes metric dimensions are consistent for each element in the array, and null values are used
+ */
+export const packMetrics = (metrics: Metric[]): MetricPack => {
+  let pack: MetricPack = { dimensions: [], data: [] };
+  if (metrics.length === 0) return pack;
+
+  const keys = Object.keys(metrics[0]).sort();
+  pack.dimensions = keys;
+
+  const packData: MetricPack["data"] = [];
+  // Pack data values, for-loop for speed
+  for (var a = 0, ml = metrics.length; a < ml; ++a) {
+    let curMetric = metrics[a];
+    let curRow: MetricPack["data"][0] = [];
+    for (var b = 0, kl = keys.length; b < kl; ++b) {
+      let curKey = keys[b];
+      curRow.push(curMetric[curKey]);
+    }
+    packData.push(curRow);
+  }
+  pack.data = packData;
+
+  return pack;
+};
+
+/**
+ * Converts MetricPack to a Metric array
+ * @param metricPack
+ * @returns
+ */
+export const unpackMetrics = (metricPack: MetricPack): Metric[] => {
+  let metrics: Metric[] = [];
+
+  for (var a = 0, ml = metricPack.data.length; a < ml; ++a) {
+    let curRow = metricPack.data[a];
+    let curMetric = createMetric({});
+    for (var b = 0, kl = metricPack.dimensions.length; b < kl; ++b) {
+      const curDimension = metricPack.dimensions[b];
+      curMetric[curDimension] = curRow[b];
+    }
+    metrics.push(curMetric);
+  }
+
+  return metrics;
 };
 
 /**

--- a/packages/geoprocessing/src/types/metrics.ts
+++ b/packages/geoprocessing/src/types/metrics.ts
@@ -40,6 +40,12 @@ export interface Metric {
   sketchId: Nullable<string>;
 }
 
+/** Alternative JSON format for metrics data that is smaller in size, better suited for blob storage and network transport */
+export interface MetricPack {
+  dimensions: string[];
+  data: (string | number | boolean | JSONValue)[][];
+}
+
 //// AGGREGATIONS ////
 
 /**

--- a/packages/geoprocessing/src/types/metrics.ts
+++ b/packages/geoprocessing/src/types/metrics.ts
@@ -2,7 +2,7 @@ import { Nullable, JSONValue } from "./base";
 import { MetricProperties } from "../metrics/helpers";
 
 /** Dimensions used in Metric */
-const MetricDimensions = [
+export const MetricDimensions = [
   "metricId",
   "geographyId",
   "sketchId",

--- a/packages/wiki-docs/Contributing.md
+++ b/packages/wiki-docs/Contributing.md
@@ -181,11 +181,13 @@ Making changes to framework CLI commands for example such as `init`, `build`, `i
 
 ## Init example project
 
+This will run the project init function directly from your library build.  When you run it, call your project something lik example-project-[insert some unique word] to avoid collisions with any other projects
+
 ```bash
 cd /PATH/TO/geoprocessing
 npm install # make sure all installed, and prepre is run doing a build
 cd packages
-node geoprocessing/dist/scripts/init/init.js # call it example-project
+node geoprocessing/dist/scripts/init/init.js # follow the tutorial if needed
 npm install # lerna will replace with symlink to sibling geoprocessing
 ```
 
@@ -242,7 +244,6 @@ The parameters you may want to change include:
 - `language` - en or English is the default.  You can choose any supported language, for example `pt` for Portuguese.
 - `geometryUri` - this is the URL that report clients will give to geoprocessing functions to load the sketch from to operate on.  Change it to any valid sketch URL.
 - `sketchProperties` - these are the sketch properties that seasketch would normally pass to the report client.  You can override these however you want, which you will need to if you have report clients that require or change their behavior depending on sketch attributes present.
-
 
 ## Test local gp project against local geoprocessing
 


### PR DESCRIPTION
Resolves #172 

This implements within the TaskModel.  on task `complete` it inspects the result payload and if `metrics` key exists and has the form of a metrics array, then it transforms it to `MetricPack` form before going into dynamodb.  It then unpacks it on `get`.  The caller never sees this.

Reduces size on average 50-75%.

There could be some further efficiency to letting the gp function pack the metrics, then sending the reduced size metrics payload to the client, and unpacking it there, but that would result in gp function smoke test output being packed, and not as easy to read.  This is being left as a database model optimization to avoid the 400KB limit.