### PR TITLE
Remove side effects from metric helper functions

### DIFF
--- a/packages/geoprocessing/src/aws/tasks.test.ts
+++ b/packages/geoprocessing/src/aws/tasks.test.ts
@@ -1,6 +1,7 @@
 import { createMetric, isMetricArray, isMetricPack } from "../metrics";
 import TaskModel from "./tasks";
 import { DynamoDB } from "aws-sdk";
+import deepEqual from "fast-deep-equal";
 
 const db = new DynamoDB.DocumentClient({
   endpoint: "localhost:8000",
@@ -145,13 +146,16 @@ test("complete a task with metrics should have packed in db", async () => {
 
 test("completed task with metrics should return unpacked result", async () => {
   const task = await Tasks.create(SERVICE_NAME);
-  const response = await Tasks.complete(task, {
-    metrics: [createMetric({ value: 15 })],
+  const metrics = [createMetric({ value: 15 })];
+  await Tasks.complete(task, {
+    metrics,
   });
   const cachedResult = await Tasks.get(SERVICE_NAME, task.id);
 
+  const cachedMetrics = cachedResult?.data.metrics;
   expect(cachedResult?.data.metrics).toBeTruthy();
   expect(isMetricArray(cachedResult?.data.metrics)).toBe(true);
+  expect(deepEqual(cachedMetrics, metrics)).toBe(true);
 });
 
 test("fail a task", async () => {

--- a/packages/geoprocessing/src/aws/tasks.ts
+++ b/packages/geoprocessing/src/aws/tasks.ts
@@ -146,8 +146,9 @@ export default class TasksModel {
 
     // Check for metrics and pack them before inserting into DB
     const dataToStore = cloneDeep(results);
-    if (results.metrics && isMetricArray(results.metrics)) {
-      dataToStore.metrics = packMetrics(results.metrics);
+    if (dataToStore.metrics && isMetricArray(dataToStore.metrics)) {
+      const packed = packMetrics(dataToStore.metrics);
+      dataToStore.metrics = packed;
     }
     await this.db
       .update({

--- a/packages/geoprocessing/src/metrics/helpers.test.ts
+++ b/packages/geoprocessing/src/metrics/helpers.test.ts
@@ -12,6 +12,8 @@ import {
   unpackMetrics,
   isMetric,
   isMetricArray,
+  rekeyMetrics,
+  MetricProperties,
 } from "./helpers";
 import { NullSketch, NullSketchCollection, Metric } from "../types";
 import { toPercentMetric } from "../../client-core";
@@ -287,14 +289,39 @@ describe("Metric checks", () => {
   });
 });
 
+test("rekeyMetrics", async () => {
+  const metrics = [createMetric({ value: 10 })];
+  const rekeyed = rekeyMetrics(metrics);
+  expect(rekeyed.length).toBe(1);
+  const keys = Object.keys(rekeyed[0]);
+  expect(keys.length).toBeLessThanOrEqual(MetricProperties.length);
+
+  // Add test of correct key order
+});
+
 describe("MetricPack", () => {
   test("Can pack and unpack metrics", async () => {
+    const metrics: Metric[] = [
+      createMetric({
+        metricId: metricName,
+        sketchId: sketchAId,
+        value: 10,
+        classId: "class1",
+      }),
+      createMetric({
+        metricId: metricName,
+        sketchId: sketchBId,
+        value: 20,
+        classId: "class1",
+      }),
+    ];
+
     const packed = packMetrics(metrics);
     expect(packed.hasOwnProperty("dimensions")).toBe(true);
     expect(packed.hasOwnProperty("data")).toBe(true);
-    expect(packed.dimensions).toHaveLength(7);
-    expect(packed.data).toHaveLength(8);
-    expect(packed.data[0]).toHaveLength(7);
+    expect(packed.dimensions).toHaveLength(6);
+    expect(packed.data).toHaveLength(2);
+    expect(packed.data[0]).toHaveLength(6);
 
     const unpacked = unpackMetrics(packed);
     expect(unpacked).toHaveLength(metrics.length);


### PR DESCRIPTION
Make packMetrics, unpackMetrics, rekeyMetrics return new data (via deep clone) instead of using input directly.  Also ensure rekeyMetrics cannot add new properties to the metric that didn't exist before (`extra` may have been getting inserted).

Resolves bug with metrics returned by ousDemographicOverlap in azores-nearshore-reports suddenly mutating right before insertion into dynamodb with additional `extra` parameter.  May have been a combination of things here.