### PR TITLE
Adds defaults and NaN validation for project bbox, closes #216

### DIFF
--- a/packages/geoprocessing/scripts/init/createProject.test.ts
+++ b/packages/geoprocessing/scripts/init/createProject.test.ts
@@ -148,13 +148,13 @@ describe("createProject", () => {
         region: "us-west-1",
         templates: [],
         planningAreaType: "other",
-        bboxMaxLat: -180,
-        bboxMinLat: 180,
-        bboxMaxLng: -90,
-        bboxMinLng: 90,
+        bboxMaxLat: 90,
+        bboxMinLat: -90,
+        bboxMaxLng: 180,
+        bboxMinLng: -180,
         planningAreaId: "Test Area",
-        planningAreaName: "Samoa",
-        planningAreaNameQuestion: "yes",
+        planningAreaName: "",
+        planningAreaNameQuestion: "no",
       },
       false,
       rootPath
@@ -168,6 +168,15 @@ describe("createProject", () => {
     expect(packageJson.description).toBe("");
     expect(packageJson.license).toBe("UNLICENSED");
     expect(packageJson.author).toBe("");
+
+    const basicJson = JSON.parse(
+      fs
+        .readFileSync(path.join(projectPath, "project", "basic.json"))
+        .toString()
+    );
+
+    expect(basicJson.bbox).toEqual([-180, -90, 180, 90]);
+    expect(basicJson.planningAreaName).toEqual("Test Area");
 
     const gpConfig = JSON.parse(
       fs.readFileSync(projectPath + "/geoprocessing.json").toString()

--- a/packages/geoprocessing/scripts/init/createProject.test.ts
+++ b/packages/geoprocessing/scripts/init/createProject.test.ts
@@ -132,4 +132,52 @@ describe("createProject", () => {
     expect(gpConfig.geoprocessingFunctions.length).toBeGreaterThan(0);
     expect(gpConfig.clients.length).toBeGreaterThan(0);
   }, 120000);
+
+  it("should create empty project with all defaults", async () => {
+    const projectName = "test-project-empty-defaults";
+    const projectPath = path.join(rootPath, projectName);
+    await createProject(
+      {
+        name: projectName,
+        description: "",
+        author: "",
+        email: "",
+        license: "UNLICENSED",
+        organization: "",
+        repositoryUrl: "",
+        region: "us-west-1",
+        templates: [],
+        planningAreaType: "other",
+        bboxMaxLat: -180,
+        bboxMinLat: 180,
+        bboxMaxLng: -90,
+        bboxMinLng: 90,
+        planningAreaId: "Test Area",
+        planningAreaName: "Samoa",
+        planningAreaNameQuestion: "yes",
+      },
+      false,
+      rootPath
+    );
+
+    const packageJson = JSON.parse(
+      fs.readFileSync(path.join(projectPath, "package.json")).toString()
+    );
+
+    expect(packageJson.name).toBe(projectName);
+    expect(packageJson.description).toBe("");
+    expect(packageJson.license).toBe("UNLICENSED");
+    expect(packageJson.author).toBe("");
+
+    const gpConfig = JSON.parse(
+      fs.readFileSync(projectPath + "/geoprocessing.json").toString()
+    ) as GeoprocessingJsonConfig;
+
+    expect(gpConfig.author).toBe("");
+    expect(gpConfig.organization).toBe("");
+    expect(gpConfig.region).toBe("us-west-1");
+    expect(gpConfig.preprocessingFunctions.length).toBe(0);
+    expect(gpConfig.geoprocessingFunctions.length).toBe(0);
+    expect(gpConfig.clients.length).toBe(0);
+  }, 120000);
 });

--- a/packages/geoprocessing/scripts/init/init.ts
+++ b/packages/geoprocessing/scripts/init/init.ts
@@ -155,6 +155,8 @@ async function init(gpVersion?: string) {
       name: "planningAreaId",
       message:
         "What is the name of the planning area as it should be displayed in reports? (e.g. Samoa)",
+      validate: (value) =>
+        value === "" ? "Provide a name for your planning area" : true,
     },
     {
       when: (answers) => answers.planningAreaType === "other",
@@ -162,8 +164,8 @@ async function init(gpVersion?: string) {
       name: "bboxMinLng",
       message:
         "What is the projects minimum longitude (left) in degrees (-180.0 to 180.0)?",
-      validate: (value) =>
-        value !== "" && isNaN(parseFloat(value)) ? "Not a number!" : true,
+      default: -180,
+      validate: (value) => (isNaN(parseFloat(value)) ? "Not a number!" : true),
       filter: (value) => (isNaN(parseFloat(value)) ? value : parseFloat(value)),
     },
     {
@@ -171,9 +173,9 @@ async function init(gpVersion?: string) {
       type: "input",
       name: "bboxMinLat",
       message:
-        "What is the projects minimum latitude (bottom) in degrees (-180.0 to 180.0)?",
-      validate: (value) =>
-        value !== "" && isNaN(parseFloat(value)) ? "Not a number!" : true,
+        "What is the projects minimum latitude (bottom) in degrees (-90.0 to 90.0)?",
+      default: -90,
+      validate: (value) => (isNaN(parseFloat(value)) ? "Not a number!" : true),
       filter: (value) => (isNaN(parseFloat(value)) ? value : parseFloat(value)),
     },
     {
@@ -182,8 +184,8 @@ async function init(gpVersion?: string) {
       name: "bboxMaxLng",
       message:
         "What is the projects maximum longitude (right) in degrees (-180.0 to 180.0)?",
-      validate: (value) =>
-        value !== "" && isNaN(parseFloat(value)) ? "Not a number!" : true,
+      default: 180,
+      validate: (value) => (isNaN(parseFloat(value)) ? "Not a number!" : true),
       filter: (value) => (isNaN(parseFloat(value)) ? value : parseFloat(value)),
     },
     {
@@ -191,9 +193,9 @@ async function init(gpVersion?: string) {
       type: "input",
       name: "bboxMaxLat",
       message:
-        "What is the projects maximum latitude (top) in degrees (-180.0 to 180.0)?",
-      validate: (value) =>
-        value !== "" && isNaN(parseFloat(value)) ? "Not a number!" : true,
+        "What is the projects maximum latitude (top) in degrees (-90.0 to 90.0)?",
+      default: 90,
+      validate: (value) => (isNaN(parseFloat(value)) ? "Not a number!" : true),
       filter: (value) => (isNaN(parseFloat(value)) ? value : parseFloat(value)),
     },
     templateQuestion,


### PR DESCRIPTION
Fixes bug where entering blank planning area coordinates causes failed init. Adds default planning area values (-180, 180, -90, 90) and refuses blank input.

Closes #216.