### PR TITLE
SegmentControl UI fix

### DIFF
--- a/packages/geoprocessing/src/components/SegmentControl.tsx
+++ b/packages/geoprocessing/src/components/SegmentControl.tsx
@@ -3,12 +3,14 @@ export interface SegmentControlProps {
   segments: { id: string; label: string }[];
   value: string;
   onClick?: (segment: string) => void;
-  // disabled?: boolean;
 }
 
 export const SegmentControl = (props: SegmentControlProps) => {
   const index = props.segments.findIndex((seg) => seg.id === props.value);
-  const [segmentSizes, setSegmentSizes] = useState<number[]>();
+  // Initialize approximate segment width
+  const [segmentWidth, setSegmentWidth] = useState<number>(
+    480 / props.segments.length
+  );
   const containerRef = useRef<HTMLDivElement>(null);
   if (index === -1) {
     throw new Error(
@@ -17,27 +19,11 @@ export const SegmentControl = (props: SegmentControlProps) => {
       )}`
     );
   }
-  let position = "0px";
-  // let position = `${(index / props.segments.length) * 100}%`;
-  if (segmentSizes) {
-    const widths = segmentSizes.slice(0, index).reduce((px, w) => (px += w), 0);
-    position = `${widths}px`;
-  }
 
+  // Update segment width when container is fully rendered
   useEffect(() => {
-    if (containerRef.current) {
-      const sizes: number[] = [];
-      for (const child of containerRef.current.childNodes) {
-        child as HTMLSpanElement;
-        if (child.nodeName === "SPAN") {
-          const span = child as HTMLSpanElement;
-          if (span.getAttribute("role") !== "button") {
-            sizes.push(span.clientWidth);
-          }
-        }
-      }
-      setSegmentSizes(sizes);
-    }
+    if (containerRef.current?.clientWidth)
+      setSegmentWidth(containerRef.current.clientWidth / props.segments.length);
   }, [containerRef.current]);
 
   return (
@@ -60,23 +46,17 @@ export const SegmentControl = (props: SegmentControlProps) => {
           transitionProperty: "all",
           transitionTimingFunction: "cubic-bezier(0.4, 0, 0.2, 1)",
           transitionDuration: "75ms",
-          insetInlineStart: position,
-          width: `${segmentSizes ? segmentSizes[index] : 0}px`,
+          insetInlineStart: `${segmentWidth * index}px`,
+          width: `${segmentWidth - 4}px`,
           fontSize: "0.875rem",
           lineHeight: "1.25rem",
           borderRadius: "0.25rem",
           padding: "0.125rem",
-          // paddingTop: "0.25rem",
-          // paddingBottom: "0.25rem",
-
           backgroundColor: "white",
           boxShadow:
             "0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -1px rgba(0, 0, 0, 0.06)",
-          //         --tw-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -1px rgba(0, 0, 0, 0.06);
-          // box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
           position: "absolute",
         }}
-        // className="transition-all duration-75 text-sm rounded p-0.5 bg-white shadow-md absolute focus:ring focus:ring-blue-200"
       >
         &nbsp;
       </span>
@@ -95,11 +75,10 @@ export const SegmentControl = (props: SegmentControlProps) => {
             lineHeight: "1.25rem",
             flex: "1 1 auto",
             textAlign: "center",
+            width: `${segmentWidth}px`,
             cursor: "pointer",
             borderRadius: "0.375rem",
             padding: "0.125rem",
-            // paddingTop: "0.25rem",
-            // paddingBottom: "0.25rem",
             zIndex: 10,
             whiteSpace: "nowrap",
             textOverflow: "ellipsis",


### PR DESCRIPTION
![Kapture 2023-10-10 at 09 27 43](https://github.com/seasketch/geoprocessing/assets/22669217/c03ce1f6-623e-40f3-9d34-9f954a9ae3d0)

The SegmentControl highlight has an initialized value and waits for it's container to be fully rendered (have a non-zero width) before updating segment widths. Also switches to equal-width segments to follow general ui guidelines for segmented controls. 

Tested with gp version `4.0.1-experimental-segmentControl.12` in [Belize reports](https://www.seasketch.org/belize/) 