### PR TITLE
Add default area value for raster precalc

### DIFF
--- a/packages/geoprocessing/src/toolbox/geoblaze/rasterStats.test.ts
+++ b/packages/geoprocessing/src/toolbox/geoblaze/rasterStats.test.ts
@@ -118,14 +118,15 @@ describe("rasterStats", () => {
 
     const statsByBand = await rasterStats(multiBandRaster, {
       feature: testData.outsideQuadPoly,
-      stats: ["sum", "count", "min", "max", "mode", "invalid", "valid"],
+      stats: ["sum", "count", "min", "max", "mode", "invalid", "valid", "area"],
     });
 
     const stats = statsByBand[0];
     const statNames = Object.keys(stats);
-    expect(statNames.length).toEqual(7);
+    expect(statNames.length).toEqual(8);
     statNames.forEach((statName) => {
-      expect(stats[statName]).toEqual(defaultStatValues[statName]);
+      if (statName === "area") expect(stats[statName]).toEqual(0);
+      else expect(stats[statName]).toEqual(defaultStatValues[statName]);
     });
     // should return zero values for each stat if no feature overlap
   });

--- a/packages/geoprocessing/src/toolbox/geoblaze/rasterStats.ts
+++ b/packages/geoprocessing/src/toolbox/geoblaze/rasterStats.ts
@@ -56,7 +56,8 @@ export const rasterStats = async (
   for (let i = 0; i < numBands; i++) {
     defaultStats[i] = {};
     for (let j = 0; j < stats.length; j++) {
-      defaultStats[i][stats[j]] = defaultStatValues[stats[j]];
+      if (stats[j] === "area") defaultStats[i][stats[j]] = 0;
+      else defaultStats[i][stats[j]] = defaultStatValues[stats[j]];
     }
   }
 


### PR DESCRIPTION
Bug fix for raster precalc, sets a default area value to avoid undefined metric area if geoblaze throws during raster stats calculation

Tested with `6.1.2-experimental-equalAreaBugFix.0` in `azores-nearshore-reports`