### PR TITLE
Adds overlapRasterGroupMetrics function

### DIFF
--- a/packages/geoprocessing/src/toolbox/overlapGroupMetrics.test.ts
+++ b/packages/geoprocessing/src/toolbox/overlapGroupMetrics.test.ts
@@ -4,10 +4,12 @@
 
 import {
   overlapAreaGroupMetrics,
+  overlapFeaturesGroupMetrics,
   overlapRasterGroupMetrics,
 } from "./overlapGroupMetrics";
-import { SketchCollection, Polygon, Metric, Sketch } from "../types";
+import { SketchCollection, Polygon, Metric, Sketch, Feature } from "../types";
 import parseGeoraster from "georaster";
+import { toFeaturePolygonArray } from "../helpers";
 
 const sketch: SketchCollection<Polygon> = {
   type: "FeatureCollection",
@@ -200,6 +202,57 @@ describe("overlapAreaGroupMetrics", () => {
         expect(curLevelMetric.value).toBe(0);
       }
     });
+  });
+
+  test("function is present", () => {
+    expect(typeof overlapFeaturesGroupMetrics).toBe("function");
+  });
+
+  test("overlapFeaturesGroupMetrics", async () => {
+    const featMetrics: Metric[] = [
+      {
+        metricId: "test",
+        value: 46020431.777366,
+        classId: "world",
+        groupId: null,
+        geographyId: null,
+        sketchId: "62055aac9557604f3e5f6d3e",
+        extra: { sketchName: "VitoriaNorth" },
+      },
+      {
+        metricId: "test",
+        value: 10335615.29727,
+        classId: "world",
+        groupId: null,
+        geographyId: null,
+        sketchId: "62055ac19557604f3e5f6d43",
+        extra: { sketchName: "VitoriaSouth" },
+      },
+      {
+        metricId: "test",
+        value: 56356047.074636,
+        classId: "world",
+        groupId: null,
+        geographyId: null,
+        sketchId: "62055ac79557604f3e5f6d44",
+        extra: { sketchName: "Vitoria", isCollection: true },
+      },
+    ];
+    const features = toFeaturePolygonArray(sketch);
+    const featuresByClass: Record<string, Feature<Polygon>[]> = {
+      world: features as Feature<Polygon>[],
+    };
+
+    const metrics = await overlapFeaturesGroupMetrics({
+      metricId: "featuresOverlap",
+      groupIds: protectionLevels,
+      sketch,
+      metricToGroup: metricToLevel,
+      metrics: featMetrics,
+      featuresByClass: featuresByClass,
+    });
+
+    expect(metrics.length).toEqual(protectionLevels.length);
   });
 
   test("function is present", () => {

--- a/packages/geoprocessing/src/toolbox/overlapGroupMetrics.ts
+++ b/packages/geoprocessing/src/toolbox/overlapGroupMetrics.ts
@@ -44,7 +44,7 @@ export async function overlapRasterGroupMetrics(options: {
   metricToGroup: (sketchMetric: Metric) => string;
   /** The metrics to group */
   metrics: Metric[];
-  /** Raster to overlap, keyed by class ID, use empty array if overlapArea operation */
+  /** Raster to overlap, keyed by class ID */
   featuresByClass: Record<string, Georaster>;
   /** only generate metrics for groups that sketches match to, rather than all */
   onlyPresentGroups?: boolean;

--- a/packages/geoprocessing/src/toolbox/overlapGroupMetrics.ts
+++ b/packages/geoprocessing/src/toolbox/overlapGroupMetrics.ts
@@ -5,6 +5,7 @@ import {
   MultiPolygon,
   SketchCollection,
   Metric,
+  Georaster,
 } from "../types";
 import {
   genSampleSketchCollection,
@@ -13,19 +14,60 @@ import {
   isSketchCollection,
   groupBy,
   clip,
+  isPolygonFeatureArray,
 } from "../helpers";
-import { createMetric } from "../metrics";
+import { createMetric, firstMatchingMetric } from "../metrics";
 import { overlapFeatures } from "./overlapFeatures";
 import { overlapArea } from "./overlapArea";
 import flatten from "@turf/flatten";
 import { featureCollection } from "@turf/helpers";
 import cloneDeep from "lodash/cloneDeep";
+import { rasterMetrics } from "./rasterMetrics";
 
 type OverlapGroupOperation = (
   metricId: string,
-  features: Feature<Polygon>[],
+  features: Feature<Polygon>[] | Georaster,
   sc: SketchCollection<Polygon>
 ) => Promise<number>;
+
+/**
+ * Generate overlap group metrics using rasterMetrics operation
+ */
+export async function overlapRasterGroupMetrics(options: {
+  /** Caller-provided metric ID */
+  metricId: string;
+  /** Group identifiers - will generate group metric for each, even if result in zero value, so pre-filter if want to limit */
+  groupIds: string[];
+  /** Sketch - single or collection */
+  sketch: Sketch<Polygon> | SketchCollection<Polygon>;
+  /** Function that given sketch metric and group name, returns true if sketch is in the group, otherwise false */
+  metricToGroup: (sketchMetric: Metric) => string;
+  /** The metrics to group */
+  metrics: Metric[];
+  /** Raster to overlap, keyed by class ID, use empty array if overlapArea operation */
+  featuresByClass: Record<string, Georaster>;
+  /** only generate metrics for groups that sketches match to, rather than all */
+  onlyPresentGroups?: boolean;
+}): Promise<Metric[]> {
+  return overlapGroupMetrics({
+    ...options,
+    operation: async (
+      metricId: string,
+      features: Georaster | Feature<Polygon>[],
+      sc: SketchCollection<Polygon>
+    ) => {
+      if (isPolygonFeatureArray(features)) throw new Error(`Expected raster`);
+      const overallGroupMetrics = await rasterMetrics(features, {
+        metricId: metricId,
+        feature: sc,
+      });
+      return firstMatchingMetric(
+        overallGroupMetrics,
+        (m) => !!m.extra?.isCollection
+      ).value;
+    },
+  });
+}
 
 /**
  * Generate overlap group metrics using overlapFeatures operation
@@ -50,9 +92,12 @@ export async function overlapFeaturesGroupMetrics(options: {
     ...options,
     operation: async (
       metricId: string,
-      features: Feature<Polygon>[],
+      features: Feature<Polygon>[] | Georaster,
       sc: SketchCollection<Polygon>
     ) => {
+      if (!isPolygonFeatureArray(features))
+        throw new Error(`Expected feature array`);
+
       const overallGroupMetrics = await overlapFeatures(
         metricId,
         features,
@@ -91,7 +136,7 @@ export async function overlapAreaGroupMetrics(options: {
     featuresByClass: { [options.classId]: [] },
     operation: async (
       metricId: string,
-      features: Feature<Polygon>[],
+      features: Feature<Polygon>[] | Georaster,
       sc: SketchCollection<Polygon>
     ) => {
       // Calculate just the overall area sum for group
@@ -130,7 +175,9 @@ export async function overlapGroupMetrics(options: {
   /** The metrics to group */
   metrics: Metric[];
   /** features to overlap, keyed by class ID, use empty array if overlapArea operation */
-  featuresByClass: Record<string, Feature<Polygon>[]>;
+  featuresByClass:
+    | Record<string, Feature<Polygon>[]>
+    | Record<string, Georaster>;
   /** overlap operation, defaults to overlapFeatures */
   operation: OverlapGroupOperation;
   /** only generate metrics for groups that sketches match to, rather than all groupIds */
@@ -226,7 +273,7 @@ const getClassGroupMetrics = async (options: {
   groups: string[];
   groupId: string;
   metricId: string;
-  features: Feature<Polygon>[];
+  features: Feature<Polygon>[] | Georaster;
   operation: OverlapGroupOperation;
 }): Promise<Metric[]> => {
   const {
@@ -338,7 +385,7 @@ const getReducedGroupAreaOverlap = async (options: {
   /** sketches in other groups that take precedence and overlap must be removed.  */
   higherGroupSketches: Sketch<Polygon>[];
   /** polygon features to overlap with */
-  features: Feature<Polygon>[];
+  features: Feature<Polygon>[] | Georaster;
   operation: OverlapGroupOperation;
 }) => {
   const { metricId, groupSketches, higherGroupSketches, features, operation } =


### PR DESCRIPTION
Functions calculating "grouped" metrics exist in the gp library for overlapFeatures and overlapArea, but not for raster overlap analysis.

Adds a corresponding `overlapRasterGroupMetrics` function to go along with the `overlapAreaGroupMetrics` and `overlapFeaturesGroupMetrics` functions, bringing this functionality from in-project code in the Belize reports.

Experimental release `6.1.3-experimental-rasterGroupMetrics.0` was tested in the [Belize reports](https://github.com/seasketch/belize-reports) and confirmed working. 