### PR TITLE
Add overlap report create:report

### DIFF
--- a/packages/base-project/package.json
+++ b/packages/base-project/package.json
@@ -27,6 +27,7 @@
     "translation:sync": "npm run translation:extract && npm run translation:publish && npm run translation:import",
     "create:function": "geoprocessing create:function",
     "create:client": "geoprocessing create:client",
+    "create:report": "geoprocessing create:report",
     "start:client": "geoprocessing start:client",
     "synth": "geoprocessing synth",
     "bootstrap": "geoprocessing bootstrap",

--- a/packages/geoprocessing/scripts/geoprocessing.ts
+++ b/packages/geoprocessing/scripts/geoprocessing.ts
@@ -86,6 +86,12 @@ if (process.argv.length < 3) {
         stdio: "inherit",
       });
       break;
+    case "create:report":
+      spawn("node", [`${__dirname}/init/createReport.js`], {
+        cwd: process.cwd(),
+        stdio: "inherit",
+      });
+      break;
     case "build:lambda":
       spawn(`${__dirname}/../../scripts/build/build.sh`, {
         cwd: process.cwd(),

--- a/packages/geoprocessing/scripts/init/createReport.ts
+++ b/packages/geoprocessing/scripts/init/createReport.ts
@@ -4,8 +4,11 @@ import fs from "fs-extra";
 import path from "path";
 import chalk from "chalk";
 import camelcase from "camelcase";
-import { ExecutionMode, metricsSchema } from "../../src/types";
-import { GeoprocessingJsonConfig } from "../../src/types";
+import {
+  ExecutionMode,
+  metricGroupsSchema,
+  GeoprocessingJsonConfig,
+} from "../../src/types";
 import {
   getBlankComponentPath,
   getBlankFunctionPath,
@@ -64,7 +67,7 @@ const createReport = async () => {
     const rawMetrics = fs.readJSONSync(
       `${getProjectConfigPath("")}/metrics.json`
     );
-    const metrics = metricsSchema.parse(rawMetrics);
+    const metrics = metricGroupsSchema.parse(rawMetrics);
     const titleChoiceQuestion = {
       type: "list",
       name: "title",

--- a/packages/geoprocessing/scripts/init/createReport.ts
+++ b/packages/geoprocessing/scripts/init/createReport.ts
@@ -1,0 +1,266 @@
+import inquirer from "inquirer";
+import ora from "ora";
+import fs from "fs-extra";
+import path from "path";
+import chalk from "chalk";
+import camelcase from "camelcase";
+import { ExecutionMode, metricsSchema } from "../../src/types";
+import { GeoprocessingJsonConfig } from "../../src/types";
+import {
+  getBlankComponentPath,
+  getBlankFunctionPath,
+  getOceanEEZComponentPath,
+  getOceanEEZFunctionPath,
+  getProjectComponentPath,
+  getProjectConfigPath,
+  getProjectFunctionPath,
+} from "../util/getPaths";
+
+const createReport = async () => {
+  const answers = await inquirer.prompt([
+    {
+      type: "list",
+      name: "type",
+      message: "Type of report to create",
+      choices: [
+        {
+          value: "blank",
+          name: "Blank report",
+        },
+        {
+          value: "raster",
+          name: "Raster overlap report - Calculates sketch overlap with raster data sources",
+        },
+        {
+          value: "vector",
+          name: "Vector overlap report - Calculates sketch overlap with vector data sources",
+        },
+      ],
+    },
+    {
+      type: "input",
+      name: "description",
+      message: "Describe what this report calculates",
+    },
+    {
+      type: "list",
+      name: "executionMode",
+      message: "Choose an execution mode for this report",
+      choices: [
+        {
+          value: "sync",
+          name: "Sync - Best for quick analyses (< 2s)",
+        },
+        {
+          value: "async",
+          name: "Async - Better for long-running processes",
+        },
+      ],
+    },
+  ]);
+
+  // Get title of report either from metrics.json or user input
+  if (answers.type === "raster" || answers.type === "vector") {
+    const rawMetrics = fs.readJSONSync(
+      `${getProjectConfigPath("")}/metrics.json`
+    );
+    const metrics = metricsSchema.parse(rawMetrics);
+    const titleChoiceQuestion = {
+      type: "list",
+      name: "title",
+      message: "Select the metric group to report on",
+      choices: metrics.map((metric) => metric.metricId),
+    };
+    const { title } = await inquirer.prompt([titleChoiceQuestion]);
+    answers.title = title;
+
+    if (answers.type === "raster") {
+      const statQuestion = {
+        type: "list",
+        name: "stat",
+        message: "Statistic to calculate",
+        choices: ["sum", "count", "area"],
+      };
+      const { stat } = await inquirer.prompt([statQuestion]);
+      answers.stat = stat;
+    } else {
+      // Vector
+      answers.stat = "area";
+    }
+  } else if (answers.type === "blank") {
+    const titleQuestion = {
+      type: "input",
+      name: "title",
+      message: "Title for this report, in camelCase",
+      default: "newReport",
+      validate: (value: any) =>
+        /^\w+$/.test(value) ? true : "Please use only alphabetical characters",
+      transformer: (value: any) => camelcase(value),
+    };
+    const { title } = await inquirer.prompt([titleQuestion]);
+    answers.title = title;
+  }
+
+  return answers;
+};
+
+if (require.main === module) {
+  createReport()
+    .then(async (answers) => {
+      await makeReport(answers, true, "");
+    })
+    .catch((error) => {
+      console.error("Error occurred:", error);
+    });
+}
+
+export async function makeReport(
+  options: ReportOptions,
+  interactive = true,
+  basePath = "./"
+) {
+  // Start interactive spinner
+  const spinner = interactive
+    ? ora("Creating new report").start()
+    : { start: () => false, stop: () => false, succeed: () => false };
+  spinner.start(`creating handler from templates`);
+
+  // Get paths
+  const projectFunctionPath = getProjectFunctionPath(basePath);
+  const projectComponentPath = getProjectComponentPath(basePath);
+
+  const templateFuncPath =
+    options.type === "blank"
+      ? getBlankFunctionPath()
+      : getOceanEEZFunctionPath();
+  const templateFuncTestPath = `${getBlankFunctionPath()}/blankFunctionSmoke.test.ts`;
+  const templateCompPath =
+    options.type === "blank"
+      ? getBlankComponentPath()
+      : getOceanEEZComponentPath();
+  const templateCompStoriesPath = `${getBlankComponentPath()}/BlankCard.stories.tsx`;
+
+  if (!fs.existsSync(path.join(basePath, "src"))) {
+    fs.mkdirSync(path.join(basePath, "src"));
+  }
+  if (!fs.existsSync(path.join(basePath, "src", "functions"))) {
+    fs.mkdirSync(path.join(basePath, "src", "functions"));
+  }
+  if (!fs.existsSync(path.join(basePath, "src", "components"))) {
+    fs.mkdirSync(path.join(basePath, "src", "components"));
+  }
+
+  const defaultFuncName =
+    options.type === "raster"
+      ? "rasterFunction"
+      : options.type === "vector"
+      ? "vectorFunction"
+      : "blankFunction";
+  const defaultFuncRegex =
+    options.type === "raster"
+      ? /rasterFunction/g
+      : options.type === "vector"
+      ? /vectorFunction/g
+      : /blankFunction/g;
+  const blankFuncRegex = /blankFunction/g;
+  const defaultCompName =
+    options.type === "raster" || options.type === "vector"
+      ? "OverlapCard"
+      : "BlankCard";
+  const defaultCompRegex =
+    options.type === "raster" || options.type === "vector"
+      ? /OverlapCard/g
+      : /BlankCard/g;
+  const blankCompRegex = /BlankCard/g;
+
+  const funcCode = await fs.readFile(
+    `${templateFuncPath}/${defaultFuncName}.ts`
+  );
+  const testFuncCode = await fs.readFile(templateFuncTestPath);
+  const componentCode = await fs.readFile(
+    `${templateCompPath}/${defaultCompName}.tsx`
+  );
+  const storiesComponentCode = await fs.readFile(templateCompStoriesPath);
+
+  const funcName = options.title;
+  const compName = funcName.charAt(0).toUpperCase() + funcName.slice(1);
+
+  // Write function file
+  await fs.writeFile(
+    `${projectFunctionPath}/${funcName}.ts`,
+    funcCode
+      .toString()
+      .replace(defaultFuncRegex, funcName)
+      .replace(`"async"`, `"${options.executionMode}"`)
+      .replace("Function description", options.description)
+      .replace(`stats: ["sum"]`, `stats: ["${options.stat}"]`) // for raster
+  );
+
+  // Write function smoke test file
+  await fs.writeFile(
+    `${projectFunctionPath}/${funcName}Smoke.test.ts`,
+    testFuncCode.toString().replace(blankFuncRegex, funcName)
+  );
+
+  // Write component file
+  await fs.writeFile(
+    `${projectComponentPath}/${compName}.tsx`,
+    componentCode
+      .toString()
+      .replace(defaultCompRegex, `${compName}`)
+      .replace(defaultFuncRegex, `${funcName}`)
+      .replace(/overlapFunction/g, `${funcName}`)
+      .replace(`"sum"`, `"${options.stat}"`) // for raster/vector overlap reports
+  );
+
+  // Write component stories file
+  await fs.writeFile(
+    `${projectComponentPath}/${compName}.stories.tsx`,
+    storiesComponentCode
+      .toString()
+      .replace(blankCompRegex, `${compName}`)
+      .replace(blankFuncRegex, `${funcName}`)
+  );
+
+  // Add function to geoprocessing.json
+  const geoprocessingJson = JSON.parse(
+    fs.readFileSync(path.join(basePath, "geoprocessing.json")).toString()
+  ) as GeoprocessingJsonConfig;
+  geoprocessingJson.geoprocessingFunctions =
+    geoprocessingJson.geoprocessingFunctions || [];
+  geoprocessingJson.geoprocessingFunctions.push(
+    `src/functions/${options.title}.ts`
+  );
+  fs.writeFileSync(
+    path.join(basePath, "geoprocessing.json"),
+    JSON.stringify(geoprocessingJson, null, "  ")
+  );
+
+  // Finish and show next steps
+  spinner.succeed(`Created ${options.title} report`);
+  if (interactive) {
+    console.log(chalk.blue(`\nReport successfully created!`));
+    console.log(
+      chalk.blue(`Function: ${`${projectFunctionPath}/${funcName}.ts`}`)
+    );
+    console.log(
+      chalk.blue(`Component: ${`${projectComponentPath}/${compName}.tsx`}`)
+    );
+    console.log(`\nNext Steps:
+    * Add your new <${compName} /> component to your reports by adding it to Viability.tsx or Representation.tsx
+    * Run 'npm test' to run smoke tests against your new function
+    * View your report using 'npm start-storybook' with smoke test output
+  `);
+  }
+}
+
+export { createReport };
+
+interface ReportOptions {
+  type: string;
+  stat?: string;
+  sumProperty?: string;
+  title: string;
+  executionMode: ExecutionMode;
+  description: string;
+}

--- a/packages/geoprocessing/scripts/util/getPaths.ts
+++ b/packages/geoprocessing/scripts/util/getPaths.ts
@@ -49,6 +49,24 @@ export function getBlankClientPath() {
   return `${getBlankProjectPath()}/src/clients`;
 }
 
+export function getBlankComponentPath() {
+  return `${getBlankProjectPath()}/src/components`;
+}
+
+export function getOceanEEZProjectPath() {
+  return /dist/.test(__dirname)
+    ? `${__dirname}/../../templates/starter-templates/template-ocean-eez`
+    : `${__dirname}/../../../templates/starter-templates/template-ocean-eez`;
+}
+
+export function getOceanEEZFunctionPath() {
+  return `${getOceanEEZProjectPath()}/src/functions`;
+}
+
+export function getOceanEEZComponentPath() {
+  return `${getOceanEEZProjectPath()}/src/components`;
+}
+
 //// PROJECT PATHS ////
 
 // Functions that return relative paths to access project assets
@@ -60,6 +78,10 @@ export function getProjectPath(basePath: string = ".") {
 
 export function getProjectFunctionPath(basePath: string = ".") {
   return getProjectPath(basePath) + "src/functions";
+}
+
+export function getProjectComponentPath(basePath: string = ".") {
+  return getProjectPath(basePath) + "src/components";
 }
 
 export function getProjectConfigPath(basePath: string = ".") {

--- a/packages/geoprocessing/src/toolbox/overlapGroupMetrics.ts
+++ b/packages/geoprocessing/src/toolbox/overlapGroupMetrics.ts
@@ -5,6 +5,7 @@ import {
   MultiPolygon,
   SketchCollection,
   Metric,
+  Georaster,
 } from "../types";
 import {
   genSampleSketchCollection,
@@ -13,19 +14,60 @@ import {
   isSketchCollection,
   groupBy,
   clip,
+  isPolygonFeatureArray,
 } from "../helpers";
-import { createMetric } from "../metrics";
+import { createMetric, firstMatchingMetric } from "../metrics";
 import { overlapFeatures } from "./overlapFeatures";
 import { overlapArea } from "./overlapArea";
 import flatten from "@turf/flatten";
 import { featureCollection } from "@turf/helpers";
 import cloneDeep from "lodash/cloneDeep";
+import { rasterMetrics } from "./rasterMetrics";
 
 type OverlapGroupOperation = (
   metricId: string,
-  features: Feature<Polygon>[],
+  features: Feature<Polygon>[] | Georaster,
   sc: SketchCollection<Polygon>
 ) => Promise<number>;
+
+/**
+ * Generate overlap group metrics using rasterMetrics operation
+ */
+export async function overlapRasterGroupMetrics(options: {
+  /** Caller-provided metric ID */
+  metricId: string;
+  /** Group identifiers - will generate group metric for each, even if result in zero value, so pre-filter if want to limit */
+  groupIds: string[];
+  /** Sketch - single or collection */
+  sketch: Sketch<Polygon> | SketchCollection<Polygon>;
+  /** Function that given sketch metric and group name, returns true if sketch is in the group, otherwise false */
+  metricToGroup: (sketchMetric: Metric) => string;
+  /** The metrics to group */
+  metrics: Metric[];
+  /** Raster to overlap, keyed by class ID, use empty array if overlapArea operation */
+  featuresByClass: Record<string, Georaster>;
+  /** only generate metrics for groups that sketches match to, rather than all */
+  onlyPresentGroups?: boolean;
+}): Promise<Metric[]> {
+  return overlapGroupMetrics({
+    ...options,
+    operation: async (
+      metricId: string,
+      features: Georaster | Feature<Polygon>[],
+      sc: SketchCollection<Polygon>
+    ) => {
+      if (isPolygonFeatureArray(features)) throw new Error(`Expected raster`);
+      const overallGroupMetrics = await rasterMetrics(features, {
+        metricId: metricId,
+        feature: sc,
+      });
+      return firstMatchingMetric(
+        overallGroupMetrics,
+        (m) => !!m.extra?.isCollection
+      ).value;
+    },
+  });
+}
 
 /**
  * Generate overlap group metrics using overlapFeatures operation
@@ -50,9 +92,12 @@ export async function overlapFeaturesGroupMetrics(options: {
     ...options,
     operation: async (
       metricId: string,
-      features: Feature<Polygon>[],
+      features: Feature<Polygon>[] | Georaster,
       sc: SketchCollection<Polygon>
     ) => {
+      if (!isPolygonFeatureArray(features))
+        throw new Error(`Expected feature array`);
+
       const overallGroupMetrics = await overlapFeatures(
         metricId,
         features,
@@ -91,7 +136,7 @@ export async function overlapAreaGroupMetrics(options: {
     featuresByClass: { [options.classId]: [] },
     operation: async (
       metricId: string,
-      features: Feature<Polygon>[],
+      features: Feature<Polygon>[] | Georaster,
       sc: SketchCollection<Polygon>
     ) => {
       // Calculate just the overall area sum for group
@@ -130,7 +175,9 @@ export async function overlapGroupMetrics(options: {
   /** The metrics to group */
   metrics: Metric[];
   /** features to overlap, keyed by class ID, use empty array if overlapArea operation */
-  featuresByClass: Record<string, Feature<Polygon>[]>;
+  featuresByClass:
+    | Record<string, Feature<Polygon>[]>
+    | Record<string, Georaster>;
   /** overlap operation, defaults to overlapFeatures */
   operation: OverlapGroupOperation;
   /** only generate metrics for groups that sketches match to, rather than all groupIds */
@@ -226,7 +273,7 @@ const getClassGroupMetrics = async (options: {
   groups: string[];
   groupId: string;
   metricId: string;
-  features: Feature<Polygon>[];
+  features: Feature<Polygon>[] | Georaster;
   operation: OverlapGroupOperation;
 }): Promise<Metric[]> => {
   const {
@@ -338,7 +385,7 @@ const getReducedGroupAreaOverlap = async (options: {
   /** sketches in other groups that take precedence and overlap must be removed.  */
   higherGroupSketches: Sketch<Polygon>[];
   /** polygon features to overlap with */
-  features: Feature<Polygon>[];
+  features: Feature<Polygon>[] | Georaster;
   operation: OverlapGroupOperation;
 }) => {
   const { metricId, groupSketches, higherGroupSketches, features, operation } =

--- a/packages/template-blank-project/examples/output/fsm-east-west-coll/blankFunction.json
+++ b/packages/template-blank-project/examples/output/fsm-east-west-coll/blankFunction.json
@@ -1,0 +1,49 @@
+{
+  "metrics": [],
+  "sketch": {
+    "properties": {
+      "id": "fsm-east-west-coll",
+      "name": "fsm-east-west-coll",
+      "createdAt": "2023-01-10T17:20:33.668529+00:00",
+      "updatedAt": "2023-01-10T17:21:07.432889+00:00",
+      "description": null,
+      "collectionId": null,
+      "isCollection": true,
+      "sketchClassId": "119",
+      "userAttributes": [
+        {
+          "label": "Description",
+          "value": null,
+          "exportId": "description",
+          "fieldType": "TextArea"
+        },
+        {
+          "label": "Author(s)",
+          "value": null,
+          "exportId": "authors",
+          "fieldType": "TextArea"
+        }
+      ],
+      "include_12-24_nm_contiguous_zone": true
+    },
+    "bbox": [
+      149.3384476090506,
+      7.033915089905491,
+      167.1102326219892,
+      7.671995147373664
+    ],
+    "type": "FeatureCollection",
+    "features": [
+      {
+        "type": "Feature",
+        "properties": {
+          "name": "fsm-east-west",
+          "updatedAt": "2022-11-17T10:02:53.645Z",
+          "sketchClassId": "123abc",
+          "id": "abc123"
+        },
+        "geometry": null
+      }
+    ]
+  }
+}

--- a/packages/template-blank-project/examples/output/fsm-east-west/blankFunction.json
+++ b/packages/template-blank-project/examples/output/fsm-east-west/blankFunction.json
@@ -1,0 +1,19 @@
+{
+  "metrics": [],
+  "sketch": {
+    "type": "Feature",
+    "properties": {
+      "name": "fsm-east-west",
+      "updatedAt": "2022-11-17T10:02:53.645Z",
+      "sketchClassId": "123abc",
+      "id": "abc123"
+    },
+    "bbox": [
+      149.3384476090506,
+      7.033915089905491,
+      167.1102326219892,
+      7.671995147373664
+    ],
+    "geometry": null
+  }
+}

--- a/packages/template-blank-project/src/components/BlankCard.stories.tsx
+++ b/packages/template-blank-project/src/components/BlankCard.stories.tsx
@@ -1,0 +1,4 @@
+import { registerExampleStories } from "@seasketch/geoprocessing/storybook";
+import { BlankCard } from "./BlankCard";
+
+registerExampleStories("Project/Components/BlankCard", BlankCard);

--- a/packages/template-blank-project/src/components/BlankCard.tsx
+++ b/packages/template-blank-project/src/components/BlankCard.tsx
@@ -1,0 +1,34 @@
+import React from "react";
+import { Trans, useTranslation } from "react-i18next";
+import {
+  ReportError,
+  ResultsCard,
+  useSketchProperties,
+} from "@seasketch/geoprocessing/client-ui";
+import { GeogProp, ReportResult } from "@seasketch/geoprocessing/client-core";
+import project from "../../project";
+
+/**
+ * BlankCard component
+ */
+export const BlankCard: React.FunctionComponent<GeogProp> = (props) => {
+  const { t } = useTranslation();
+  const [{ isCollection }] = useSketchProperties();
+  const curGeography = project.getGeographyById(props.geographyId, {
+    fallbackGroup: "default-boundary",
+  });
+
+  return (
+    <ResultsCard title={t("BlankCard")} functionName="blankFunction">
+      {(data: ReportResult) => {
+        return (
+          <ReportError>
+            <p>
+              <Trans i18nKey="BlankCard Message">This is a blank report.</Trans>
+            </p>
+          </ReportError>
+        );
+      }}
+    </ResultsCard>
+  );
+};

--- a/packages/template-blank-project/src/functions/blankFunction.ts
+++ b/packages/template-blank-project/src/functions/blankFunction.ts
@@ -1,0 +1,62 @@
+import {
+  Sketch,
+  SketchCollection,
+  Polygon,
+  MultiPolygon,
+  GeoprocessingHandler,
+  getFirstFromParam,
+  DefaultExtraParams,
+  splitSketchAntimeridian,
+} from "@seasketch/geoprocessing";
+import bbox from "@turf/bbox";
+import project from "../../project";
+import {
+  ReportResult,
+  rekeyMetrics,
+  sortMetrics,
+  toNullSketch,
+} from "@seasketch/geoprocessing/client-core";
+import { clipToGeography } from "../util/clipToGeography";
+
+export async function blankFunction(
+  sketch:
+    | Sketch<Polygon | MultiPolygon>
+    | SketchCollection<Polygon | MultiPolygon>,
+  extraParams: DefaultExtraParams = {}
+): Promise<ReportResult> {
+  // Use caller-provided geographyId if provided
+  const geographyId = getFirstFromParam("geographyIds", extraParams);
+
+  // Get geography features, falling back to geography assigned to default-boundary group
+  const curGeography = project.getGeographyById(geographyId, {
+    fallbackGroup: "default-boundary",
+  });
+
+  // Support sketches crossing antimeridian
+  const splitSketch = splitSketchAntimeridian(sketch);
+
+  // Clip to portion of sketch within current geography
+  const clippedSketch = await clipToGeography(splitSketch, curGeography);
+
+  // Get bounding box of sketch remainder
+  const sketchBox = clippedSketch.bbox || bbox(clippedSketch);
+
+  // Add functionality here to return in (most common) Metric[] format
+  // Or create new type to return to component
+
+  // Return a report result with metrics and a null sketch
+  return {
+    metrics: sortMetrics(rekeyMetrics([])),
+    sketch: toNullSketch(clippedSketch, true),
+  };
+}
+
+export default new GeoprocessingHandler(blankFunction, {
+  title: "blankFunction",
+  description: "Function description",
+  timeout: 60, // seconds
+  memory: 1024, // megabytes
+  executionMode: "async",
+  // Specify any Sketch Class form attributes that are required
+  requiresProperties: [],
+});

--- a/packages/template-blank-project/src/functions/blankFunctionSmoke.test.ts
+++ b/packages/template-blank-project/src/functions/blankFunctionSmoke.test.ts
@@ -1,0 +1,23 @@
+/**
+ * @jest-environment node
+ * @group smoke
+ */
+import {
+  getExamplePolygonSketchAll,
+  writeResultOutput,
+} from "@seasketch/geoprocessing/scripts/testing";
+import { blankFunction } from "./blankFunction";
+
+describe("Basic smoke tests", () => {
+  test("handler function is present", () => {
+    expect(typeof blankFunction).toBe("function");
+  });
+  test("blankFunction - tests run against all examples", async () => {
+    const examples = await getExamplePolygonSketchAll();
+    for (const example of examples) {
+      const result = await blankFunction(example);
+      expect(result).toBeTruthy();
+      writeResultOutput(result, "blankFunction", example.properties.name);
+    }
+  }, 60000);
+});

--- a/packages/template-ocean-eez/src/components/OverlapCard.tsx
+++ b/packages/template-ocean-eez/src/components/OverlapCard.tsx
@@ -1,0 +1,166 @@
+import React from "react";
+import { Trans, useTranslation } from "react-i18next";
+import {
+  ClassTable,
+  Collapse,
+  ReportError,
+  ResultsCard,
+  SketchClassTable,
+  useSketchProperties,
+} from "@seasketch/geoprocessing/client-ui";
+import {
+  GeogProp,
+  Metric,
+  MetricGroup,
+  ReportResult,
+  flattenBySketchAllClass,
+  metricsWithSketchId,
+  toNullSketchArray,
+  toPercentMetric,
+} from "@seasketch/geoprocessing/client-core";
+import project from "../../project";
+
+/**
+ * OverlapCard component
+ *
+ * @param props - geographyId
+ * @returns A react component which displays an overlap report
+ */
+export const OverlapCard: React.FunctionComponent<GeogProp> = (props) => {
+  const { t } = useTranslation();
+  const [{ isCollection }] = useSketchProperties();
+  const curGeography = project.getGeographyById(props.geographyId, {
+    fallbackGroup: "default-boundary",
+  });
+
+  // Metrics
+  const metricGroup = project.getMetricGroup("overlapFunction", t);
+  const precalcMetrics = project.getPrecalcMetrics(
+    metricGroup,
+    "sum",
+    curGeography.geographyId
+  );
+
+  // Labels
+  const titleLabel = t("OverlapCard");
+  const mapLabel = t("Map");
+  const withinLabel = t("Within Plan");
+  const percWithinLabel = t("% Within Plan");
+  const unitsLabel = t("units");
+
+  return (
+    <ResultsCard
+      title={titleLabel}
+      functionName="overlapFunction"
+      extraParams={{ geographyIds: [curGeography.geographyId] }}
+    >
+      {(data: ReportResult) => {
+        const percMetricIdName = `${metricGroup.metricId}Perc`;
+
+        const valueMetrics = metricsWithSketchId(
+          data.metrics.filter((m) => m.metricId === metricGroup.metricId),
+          [data.sketch.properties.id]
+        );
+        const percentMetrics = toPercentMetric(valueMetrics, precalcMetrics, {
+          metricIdOverride: percMetricIdName,
+        });
+        const metrics = [...valueMetrics, ...percentMetrics];
+
+        return (
+          <ReportError>
+            <p>
+              <Trans i18nKey="OverlapCard 1">
+                This report summarizes this plan's overlap with OverlapCard
+                data.
+              </Trans>
+            </p>
+
+            <ClassTable
+              rows={metrics}
+              metricGroup={metricGroup}
+              columnConfig={[
+                {
+                  columnLabel: " ",
+                  type: "class",
+                  width: 30,
+                },
+                {
+                  columnLabel: withinLabel,
+                  type: "metricValue",
+                  metricId: metricGroup.metricId,
+                  valueFormatter: "integer",
+                  valueLabel: unitsLabel,
+                  chartOptions: {
+                    showTitle: true,
+                  },
+                  width: 20,
+                },
+                {
+                  columnLabel: percWithinLabel,
+                  type: "metricChart",
+                  metricId: percMetricIdName,
+                  valueFormatter: "percent",
+                  chartOptions: {
+                    showTitle: true,
+                  },
+                  width: 40,
+                },
+                {
+                  columnLabel: mapLabel,
+                  type: "layerToggle",
+                  width: 10,
+                },
+              ]}
+            />
+
+            {isCollection && (
+              <Collapse title={t("Show by Sketch")}>
+                {genSketchTable(data, metricGroup, precalcMetrics)}
+              </Collapse>
+            )}
+
+            <Collapse title={t("Learn More")}>
+              <Trans i18nKey="OverlapCard - learn more">
+                <p>ℹ️ Overview:</p>
+                <p>🎯 Planning Objective:</p>
+                <p>🗺️ Source Data:</p>
+                <p>
+                  📈 Report: This report calculates the total value of each
+                  feature within the plan. This value is divided by the total
+                  value of each feature to obtain the % contained within the
+                  plan. If the plan includes multiple areas that overlap, the
+                  overlap is only counted once.
+                </p>
+              </Trans>
+            </Collapse>
+          </ReportError>
+        );
+      }}
+    </ResultsCard>
+  );
+};
+
+const genSketchTable = (
+  data: ReportResult,
+  metricGroup: MetricGroup,
+  precalcMetrics: Metric[]
+) => {
+  // Build agg metric objects for each child sketch in collection with percValue for each class
+  const childSketches = toNullSketchArray(data.sketch);
+  const childSketchIds = childSketches.map((sk) => sk.properties.id);
+  const childSketchMetrics = toPercentMetric(
+    metricsWithSketchId(
+      data.metrics.filter((m) => m.metricId === metricGroup.metricId),
+      childSketchIds
+    ),
+    precalcMetrics
+  );
+  const sketchRows = flattenBySketchAllClass(
+    childSketchMetrics,
+    metricGroup.classes,
+    childSketches
+  );
+  return (
+    <SketchClassTable rows={sketchRows} metricGroup={metricGroup} formatPerc />
+  );
+};

--- a/packages/template-ocean-eez/src/functions/rasterFunction.ts
+++ b/packages/template-ocean-eez/src/functions/rasterFunction.ts
@@ -1,0 +1,107 @@
+import {
+  Sketch,
+  SketchCollection,
+  Polygon,
+  MultiPolygon,
+  GeoprocessingHandler,
+  getFirstFromParam,
+  DefaultExtraParams,
+  splitSketchAntimeridian,
+  rasterMetrics,
+  isRasterDatasource,
+} from "@seasketch/geoprocessing";
+import bbox from "@turf/bbox";
+import project from "../../project";
+import {
+  Metric,
+  ReportResult,
+  rekeyMetrics,
+  sortMetrics,
+  toNullSketch,
+} from "@seasketch/geoprocessing/client-core";
+import { clipToGeography } from "../util/clipToGeography";
+import { loadCog } from "@seasketch/geoprocessing/dataproviders";
+
+/**
+ * rasterFunction: A geoprocessing function that calculates overlap metrics
+ * @param sketch - A sketch or collection of sketches
+ * @param extraParams
+ * @returns Calculated metrics and a null sketch
+ */
+export async function rasterFunction(
+  sketch:
+    | Sketch<Polygon | MultiPolygon>
+    | SketchCollection<Polygon | MultiPolygon>,
+  extraParams: DefaultExtraParams = {}
+): Promise<ReportResult> {
+  // Use caller-provided geographyId if provided
+  const geographyId = getFirstFromParam("geographyIds", extraParams);
+
+  // Get geography features, falling back to geography assigned to default-boundary group
+  const curGeography = project.getGeographyById(geographyId, {
+    fallbackGroup: "default-boundary",
+  });
+
+  // Support sketches crossing antimeridian
+  const splitSketch = splitSketchAntimeridian(sketch);
+
+  // Clip to portion of sketch within current geography
+  const clippedSketch = await clipToGeography(splitSketch, curGeography);
+
+  // Get bounding box of sketch remainder
+  const sketchBox = clippedSketch.bbox || bbox(clippedSketch);
+
+  // Calculate overlap metrics for each class in metric group
+  const metricGroup = project.getMetricGroup("rasterFunction");
+  const metrics: Metric[] = (
+    await Promise.all(
+      metricGroup.classes.map(async (curClass) => {
+        if (!curClass.datasourceId)
+          throw new Error(`Expected datasourceId for ${curClass.classId}`);
+
+        const ds = project.getDatasourceById(curClass.datasourceId);
+        if (!isRasterDatasource(ds))
+          throw new Error(`Expected raster datasource for ${ds.datasourceId}`);
+
+        const url = project.getDatasourceUrl(ds);
+
+        // Start raster load and move on in loop while awaiting finish
+        const raster = await loadCog(url);
+
+        // Start analysis when raster load finishes
+        const overlapResult = await rasterMetrics(raster, {
+          metricId: metricGroup.metricId,
+          feature: clippedSketch,
+          stats: ["sum"],
+        });
+        return overlapResult.map(
+          (metrics): Metric => ({
+            ...metrics,
+            classId: curClass.classId,
+            geographyId: curGeography.geographyId,
+          })
+        );
+      })
+    )
+  ).reduce(
+    // merge
+    (metricsSoFar, curClassMetrics) => [...metricsSoFar, ...curClassMetrics],
+    []
+  );
+
+  // Return a report result with metrics and a null sketch
+  return {
+    metrics: sortMetrics(rekeyMetrics(metrics)),
+    sketch: toNullSketch(sketch, true),
+  };
+}
+
+export default new GeoprocessingHandler(rasterFunction, {
+  title: "rasterFunction",
+  description: "Function description",
+  timeout: 60, // seconds
+  memory: 1024, // megabytes
+  executionMode: "async",
+  // Specify any Sketch Class form attributes that are required
+  requiresProperties: [],
+});

--- a/packages/template-ocean-eez/src/functions/vectorFunction.ts
+++ b/packages/template-ocean-eez/src/functions/vectorFunction.ts
@@ -1,0 +1,126 @@
+import {
+  Sketch,
+  SketchCollection,
+  Polygon,
+  MultiPolygon,
+  GeoprocessingHandler,
+  getFirstFromParam,
+  DefaultExtraParams,
+  splitSketchAntimeridian,
+  Feature,
+  isVectorDatasource,
+  overlapFeatures,
+} from "@seasketch/geoprocessing";
+import bbox from "@turf/bbox";
+import project from "../../project";
+import {
+  Metric,
+  ReportResult,
+  rekeyMetrics,
+  sortMetrics,
+  toNullSketch,
+} from "@seasketch/geoprocessing/client-core";
+import { clipToGeography } from "../util/clipToGeography";
+import { fgbFetchAll } from "@seasketch/geoprocessing/dataproviders";
+
+/**
+ * vectorFunction: A geoprocessing function that calculates overlap metrics
+ * @param sketch - A sketch or collection of sketches
+ * @param extraParams
+ * @returns Calculated metrics and a null sketch
+ */
+export async function vectorFunction(
+  sketch:
+    | Sketch<Polygon | MultiPolygon>
+    | SketchCollection<Polygon | MultiPolygon>,
+  extraParams: DefaultExtraParams = {}
+): Promise<ReportResult> {
+  // Use caller-provided geographyId if provided
+  const geographyId = getFirstFromParam("geographyIds", extraParams);
+
+  // Get geography features, falling back to geography assigned to default-boundary group
+  const curGeography = project.getGeographyById(geographyId, {
+    fallbackGroup: "default-boundary",
+  });
+
+  // Support sketches crossing antimeridian
+  const splitSketch = splitSketchAntimeridian(sketch);
+
+  // Clip to portion of sketch within current geography
+  const clippedSketch = await clipToGeography(splitSketch, curGeography);
+
+  // Get bounding box of sketch remainder
+  const sketchBox = clippedSketch.bbox || bbox(clippedSketch);
+
+  // Chached features
+  let cachedFeatures: Record<string, Feature<Polygon | MultiPolygon>[]> = {};
+
+  // Calculate overlap metrics for each class in metric group
+  const metricGroup = project.getMetricGroup("vectorFunction");
+  const metrics = (
+    await Promise.all(
+      metricGroup.classes.map(async (curClass) => {
+        if (!curClass.datasourceId)
+          throw new Error(`Expected datasourceId for ${curClass.classId}`);
+
+        const ds = project.getDatasourceById(curClass.datasourceId);
+        if (!isVectorDatasource(ds))
+          throw new Error(`Expected vector datasource for ${ds.datasourceId}`);
+
+        const url = project.getDatasourceUrl(ds);
+
+        // Fetch features overlapping with sketch, pull from cache if already fetched
+        const features =
+          cachedFeatures[curClass.datasourceId] ||
+          (await fgbFetchAll<Feature<Polygon | MultiPolygon>>(url, sketchBox));
+        cachedFeatures[curClass.datasourceId] = features;
+
+        // If this is a sub-class, filter by class name
+        const finalFeatures =
+          curClass.classKey && curClass.classId !== `${ds.datasourceId}_all`
+            ? features.filter((feat) => {
+                return (
+                  feat.geometry &&
+                  feat.properties![ds.classKeys[0]] === curClass.classId
+                );
+              }, [])
+            : features;
+
+        // Calculate overlap metrics
+        const overlapResult = await overlapFeatures(
+          metricGroup.metricId,
+          finalFeatures,
+          clippedSketch
+        );
+
+        return overlapResult.map(
+          (metric): Metric => ({
+            ...metric,
+            classId: curClass.classId,
+            geographyId: curGeography.geographyId,
+          })
+        );
+      })
+    )
+  ).reduce(
+    // merge
+    (metricsSoFar, curClassMetrics) => [...metricsSoFar, ...curClassMetrics],
+    []
+  );
+
+  // Return a report result with metrics and a null sketch
+  return {
+    metrics: sortMetrics(rekeyMetrics(metrics)),
+    sketch: toNullSketch(sketch, true),
+  };
+}
+
+export default new GeoprocessingHandler(vectorFunction, {
+  title: "vectorFunction",
+  description: "Function description",
+  timeout: 60, // seconds
+  memory: 1024, // megabytes
+  executionMode: "async",
+  // Specify any Sketch Class form attributes that are required
+  requiresProperties: [],
+});


### PR DESCRIPTION
From https://github.com/seasketch/geoprocessing/issues/130.

Creates `create:report` cli command to build simple overlap reports given a properly configured `metricGroup`.

User chooses a metricGroup from `metrics.json` and it:
- creates function
- creates smoke test
- creates component
- creates component stories
- adds function to `geoprocessing.json`