### PR TITLE
Vitest + node-test-runner

### DIFF
--- a/packages/geoprocessing/src/toolbox/geoblaze/test/equalArea.node.test.ts
+++ b/packages/geoprocessing/src/toolbox/geoblaze/test/equalArea.node.test.ts
@@ -1,0 +1,243 @@
+// @ts-ignore
+import geoblaze from "geoblaze";
+import { describe, test } from "node:test";
+import assert from "node:assert/strict";
+import { withinRange } from "../../../util/withinRange.js";
+
+// Testing using EPSG:6933 NSIDC EASE-Grid 2.0 Global equal-area projection in geoblaze
+
+describe("geoblaze equal-area tests", () => {
+  test("discrete raster, no geometry", async () => {
+    const url =
+      "http://127.0.0.1:8080/data/in/existing_marine_reserves_6933_COG.tif";
+
+    const stats = (await geoblaze.stats(url))[0];
+
+    // QGIS Raster layer statistics results for existing_marine_reserves_6933_COG.tif:
+    // {'MAX': 1.0, 'MEAN': 0.006075020775424822, 'MIN': 0.0, 'RANGE': 1.0,
+    // 'STD_DEV': 0.0777064214188436, 'SUM': 212.0 }
+
+    // QGIS Raster layer zonal statistics for existing_marine_reserves_6933_COG.tif:
+    // Zone 1: 5730847183.38624382 m2
+
+    assert.equal(stats.max, 1);
+    assert.equal(stats.min, 0);
+    assert.equal(stats.range, 1);
+    assert(withinRange(stats.mean, 0.006075020775424822, 0.0001));
+    assert(withinRange(stats.std, 0.0777064214188436, 0.0001));
+    assert.equal(stats.sum, 212);
+  });
+
+  test.skip("cross-dateline geometry", async () => {
+    const url =
+      "http://127.0.0.1:8080/data/in/existing_marine_reserves_6933_COG.tif";
+
+    const poly = {
+      type: "Polygon",
+      coordinates: [
+        [
+          [17000000, 6000000],
+          [-17000000, 6000000],
+          [-17000000, 3000000],
+          [17000000, 3000000],
+          [17000000, 6000000],
+        ],
+      ],
+    };
+
+    const stats = (await geoblaze.stats(url, poly))[0];
+
+    // Should include 0 valid points, but cross-dateline polygons
+    // assert.equal(stats.sum).toBe(0); // fails, geoblaze: 212
+  });
+
+  test("raster and geom equal-area", async () => {
+    const url =
+      "http://127.0.0.1:8080/data/in/existing_marine_reserves_6933_COG.tif";
+
+    // Wholly contains an area
+    const poly = {
+      type: "Polygon",
+      coordinates: [
+        [
+          [-2681242.560635542497039, 4795421.535046168603003],
+          [-2511173.208286261186004, 4797508.182961687445641],
+          [-2497649.14184289611876, 4690789.620548607781529],
+          [-2669890.365794897545129, 4691838.809715726412833],
+          [-2681242.560635542497039, 4795421.535046168603003],
+        ],
+      ],
+    };
+
+    const stats = (await geoblaze.stats(url, poly))[0];
+
+    // QGIS Raster layer statistics results for existing_marine_reserves_6933_COG.tif within polygon:
+    // {'MAX': 1.0, 'MEAN': 0.24600638977635783, 'MIN': 0.0, 'RANGE': 1.0,
+    // 'STD_DEV': 0.4310267109578078, 'SUM': 154.0 }
+
+    // QGIS Raster layer zonal statistics for existing_marine_reserves_6933_COG.tif within polygon:
+    // Zone 1: 4162973897.36546230
+
+    assert.equal(stats.max, 1);
+    assert.equal(stats.min, 0);
+    assert.equal(stats.range, 1);
+    assert.equal(stats.sum, 154);
+  });
+
+  test("raster 6933, geom 4326", async () => {
+    const url =
+      "http://127.0.0.1:8080/data/in/existing_marine_reserves_6933_COG.tif";
+
+    const stats = (
+      await geoblaze.stats(url, {
+        srs: 4326,
+        geometry: {
+          type: "Polygon",
+          coordinates: [
+            [
+              [-27.788847840992702, 40.904867247459123],
+              [-26.026220533700467, 40.92638795936891],
+              [-25.886054839591441, 39.834382805634981],
+              [-27.671191788638673, 39.845034868644113],
+              [-27.788847840992702, 40.904867247459123],
+            ],
+          ],
+        },
+      })
+    )[0];
+
+    // QGIS Raster layer statistics results for existing_marine_reserves_6933_COG.tif within polygon:
+    // {'MAX': 1.0, 'MEAN': 0.24600638977635783, 'MIN': 0.0, 'RANGE': 1.0,
+    // 'STD_DEV': 0.4310267109578078, 'SUM': 154.0 }
+
+    // QGIS Raster layer zonal statistics for existing_marine_reserves_6933_COG.tif within polygon:
+    // Zone 1: 4162973897.36546230
+
+    assert.equal(stats.max, 1);
+    assert.equal(stats.min, 0);
+    assert.equal(stats.range, 1);
+    assert.equal(stats.sum, 154);
+  });
+
+  test("raster 6933, two 4326 polygons", async () => {
+    const url =
+      "http://127.0.0.1:8080/data/in/existing_marine_reserves_6933_COG.tif";
+
+    // Wholly contains an area but split down the middle, no overlap
+    const stats = (
+      await geoblaze.stats(url, {
+        srs: 4326,
+        geometry: {
+          type: "FeatureCollection",
+          features: [
+            {
+              type: "Feature",
+              properties: {},
+              geometry: {
+                coordinates: [
+                  [
+                    [-27.788847840992702, 40.904867247459123],
+                    [-26.026220533700467, 40.92638795936891],
+                    [-25.886054839591441, 40],
+                    [-27.671191788638673, 40],
+                    [-27.788847840992702, 40.904867247459123],
+                  ],
+                ],
+                type: "Polygon",
+              },
+            },
+            {
+              type: "Feature",
+              properties: {},
+              geometry: {
+                coordinates: [
+                  [
+                    [-27.788847840992702, 40],
+                    [-26.026220533700467, 40],
+                    [-25.886054839591441, 39.834382805634981],
+                    [-27.671191788638673, 39.845034868644113],
+                    [-27.788847840992702, 40],
+                  ],
+                ],
+                type: "Polygon",
+              },
+            },
+          ],
+        },
+      })
+    )[0];
+
+    // QGIS Raster layer statistics results for existing_marine_reserves_6933_COG.tif within polygons:
+    // {'MAX': 1.0, 'MEAN': 0.24600638977635783, 'MIN': 0.0, 'RANGE': 1.0,
+    // 'STD_DEV': 0.4310267109578078, 'SUM': 154.0 }
+
+    // QGIS Raster layer zonal statistics for existing_marine_reserves_6933_COG.tif within polygons:
+    // Zone 1: 4162973897.36546230
+
+    assert.equal(stats.max, 1);
+    assert.equal(stats.min, 0);
+    assert.equal(stats.range, 1);
+    assert.equal(stats.sum, 154);
+  });
+
+  test("Two polygons overlapping", async () => {
+    const url =
+      "http://127.0.0.1:8080/data/in/existing_marine_reserves_6933_COG.tif";
+
+    // Wholly contains an area but split down the middle, overlap
+    const stats = (
+      await geoblaze.stats(url, {
+        srs: 4326,
+        geometry: {
+          type: "FeatureCollection",
+          features: [
+            {
+              type: "Feature",
+              properties: {},
+              geometry: {
+                coordinates: [
+                  [
+                    [-27.5, 41],
+                    [-26, 41],
+                    [-26, 40],
+                    [-27.5, 40],
+                    [-27.5, 41],
+                  ],
+                ],
+                type: "Polygon",
+              },
+            },
+            {
+              type: "Feature",
+              properties: {},
+              geometry: {
+                coordinates: [
+                  [
+                    [-27.5, 41],
+                    [-26, 41],
+                    [-26, 40],
+                    [-27.5, 40],
+                    [-27.5, 41],
+                  ],
+                ],
+                type: "Polygon",
+              },
+            },
+          ],
+        },
+      })
+    )[0];
+
+    // QGIS Raster layer statistics results for existing_marine_reserves_6933_COG.tif within polygons:
+    // {'MAX': 1.0, 'MEAN': 0.24600638977635783, 'MIN': 0.0, 'RANGE': 1.0,
+    // 'STD_DEV': 0.4310267109578078, 'SUM': 154.0 }
+
+    // QGIS Raster layer zonal statistics for existing_marine_reserves_6933_COG.tif within polygons:
+    // Zone 1: 4162973897.36546230
+
+    assert.equal(stats.max, 1);
+    assert.equal(stats.min, 0);
+    assert.equal(stats.range, 1);
+    assert.equal(stats.sum, 154);
+  });
+});

--- a/packages/geoprocessing/src/toolbox/geoblaze/test/multipolygon.node.test.ts
+++ b/packages/geoprocessing/src/toolbox/geoblaze/test/multipolygon.node.test.ts
@@ -1,0 +1,784 @@
+import { describe, test } from "node:test";
+import assert from "node:assert/strict";
+import { withinRange } from "../../../util/withinRange.js";
+
+// @ts-ignore
+import geoblaze from "geoblaze";
+import parseGeoraster from "georaster";
+
+describe("geoblaze multipolygon tests", () => {
+  test("simple in-memory raster unit test", async () => {
+    //  Raster   whole   2polygon & multipolygon
+    //           _____            _____
+    //  [1,1]   |     |          |  |  |
+    //  [1,1]   |_____|          |__|__|
+    //
+
+    const raster = await parseGeoraster(
+      [
+        [
+          [1, 1],
+          [1, 1],
+        ],
+      ],
+      {
+        noDataValue: 0,
+        projection: 4326,
+        xmin: 0, // left
+        ymax: 20, // top
+        pixelWidth: 10,
+        pixelHeight: 10,
+      }
+    );
+
+    const whole = {
+      type: "Polygon",
+      coordinates: [
+        [
+          [1, 1],
+          [1, 19],
+          [19, 19],
+          [19, 1],
+          [1, 1],
+        ],
+      ],
+    };
+
+    const collection = {
+      type: "FeatureCollection",
+      features: [
+        {
+          type: "Feature",
+          properties: {},
+          geometry: {
+            coordinates: [
+              [
+                [1, 19],
+                [11, 19],
+                [11, 1],
+                [1, 1],
+                [1, 19],
+              ],
+            ],
+            type: "Polygon",
+          },
+        },
+        {
+          type: "Feature",
+          properties: {},
+          geometry: {
+            coordinates: [
+              [
+                [11, 19],
+                [19, 19],
+                [19, 1],
+                [11, 1],
+                [11, 19],
+              ],
+            ],
+            type: "Polygon",
+          },
+        },
+      ],
+    };
+
+    const multipolygon = {
+      type: "Feature",
+      properties: {},
+      geometry: {
+        type: "MultiPolygon",
+        coordinates: [
+          [
+            [
+              [1, 19],
+              [11, 19],
+              [11, 1],
+              [1, 1],
+              [1, 19],
+            ],
+          ],
+          [
+            [
+              [11, 19],
+              [19, 19],
+              [19, 1],
+              [11, 1],
+              [11, 19],
+            ],
+          ],
+        ],
+      },
+    };
+
+    const wholeSum = geoblaze.sum(raster, whole);
+    const singlepart = geoblaze.sum(raster, collection);
+    const multipart = geoblaze.sum(raster, multipolygon);
+
+    assert.equal(
+      wholeSum[0] === 4 && singlepart[0] === 4 && multipart[0] === 4,
+      true
+    );
+  });
+
+  test("geoblaze - compares multipolygon sum with polygon collection sum (joined edge)", async () => {
+    // Theoretically, multipolygons shouldn't share edges, but if they're made manually it might be possible
+    const url = "http://127.0.0.1:8080/data/in/feature_abyssopelagic_cog.tif";
+    const raster = await geoblaze.parse(url);
+
+    const whole = {
+      type: "Feature",
+      properties: {},
+      geometry: {
+        coordinates: [
+          [
+            [-67.86548213174478, 33.770041401853305],
+            [-66.59556949691553, 31.222453169005036],
+            [-65.98033231979333, 33.210904649209],
+            [-65.39664576713909, 35.80391270692117],
+            [-67.86548213174478, 33.770041401853305],
+          ],
+        ],
+        type: "Polygon",
+      },
+    };
+
+    const featureCollection = {
+      type: "FeatureCollection",
+      features: [
+        {
+          type: "Feature",
+          properties: {},
+          geometry: {
+            coordinates: [
+              [
+                [-67.86548213174478, 33.770041401853305],
+                [-65.98033231979333, 33.210904649209],
+                [-65.39664576713909, 35.80391270692117],
+                [-67.86548213174478, 33.770041401853305],
+              ],
+            ],
+            type: "Polygon",
+          },
+        },
+        {
+          type: "Feature",
+          properties: {},
+          geometry: {
+            coordinates: [
+              [
+                [-67.86548213174478, 33.770041401853305],
+                [-66.59556949691553, 31.222453169005036],
+                [-65.98033231979333, 33.210904649209],
+                [-67.86548213174478, 33.770041401853305],
+              ],
+            ],
+            type: "Polygon",
+          },
+        },
+      ],
+    };
+
+    const multipolygon = {
+      type: "Feature",
+      properties: {},
+      geometry: {
+        type: "MultiPolygon",
+        coordinates: [
+          [
+            [
+              [-67.86548213174478, 33.770041401853305],
+              [-65.98033231979333, 33.210904649209],
+              [-66.59556949691553, 31.222453169005036],
+              [-67.86548213174478, 33.770041401853305],
+            ],
+          ],
+          [
+            [
+              [-67.86548213174478, 33.770041401853305],
+              [-65.39664576713909, 35.80391270692117],
+              [-65.98033231979333, 33.210904649209],
+              [-67.86548213174478, 33.770041401853305],
+            ],
+          ],
+        ],
+      },
+    };
+
+    const wholeSum = await geoblaze.sum(raster, whole);
+    const singlepart = await geoblaze.sum(raster, featureCollection);
+    const multipart = await geoblaze.sum(raster, multipolygon);
+
+    // Expect the whole feature's sum to be equal to the sum of the 2 polygons
+    // and the sume of the multipolygon
+    assert.equal(
+      wholeSum[0] === multipart[0] && multipart[0] === singlepart[0],
+      true
+    );
+  });
+
+  test("geoblaze - compares multipolygon sum with polygon collection sum (no joined edge)", async () => {
+    const url = "http://127.0.0.1:8080/data/in/feature_abyssopelagic_cog.tif";
+    const raster = await geoblaze.parse(url);
+
+    const featureCollection = {
+      type: "FeatureCollection",
+      features: [
+        {
+          type: "Feature",
+          properties: {},
+          geometry: {
+            coordinates: [
+              [
+                [-63.90176969402023, 34.92136482552985],
+                [-63.447775851182215, 34.391324267381975],
+                [-64.06031498843957, 33.9948800218461],
+                [-64.35703941419384, 34.56398728233894],
+                [-63.90176969402023, 34.92136482552985],
+              ],
+            ],
+
+            type: "Polygon",
+          },
+        },
+        {
+          type: "Feature",
+          properties: {},
+          geometry: {
+            coordinates: [
+              [
+                [-66.21155520840662, 34.88568983762421],
+                [-67.66171977631797, 34.08188318255097],
+                [-66.64655816276613, 33.029451874561474],
+                [-65.31360888370416, 34.10146532497224],
+                [-66.21155520840662, 34.88568983762421],
+              ],
+            ],
+
+            type: "Polygon",
+          },
+        },
+      ],
+    };
+
+    const multipolygon = {
+      type: "Feature",
+      properties: {},
+      geometry: {
+        type: "MultiPolygon",
+        coordinates: [
+          [
+            [
+              [-63.90176969402023, 34.92136482552985],
+              [-63.447775851182215, 34.391324267381975],
+              [-64.06031498843957, 33.9948800218461],
+              [-64.35703941419384, 34.56398728233894],
+              [-63.90176969402023, 34.92136482552985],
+            ],
+          ],
+          [
+            [
+              [-66.21155520840662, 34.88568983762421],
+              [-67.66171977631797, 34.08188318255097],
+              [-66.64655816276613, 33.029451874561474],
+              [-65.31360888370416, 34.10146532497224],
+              [-66.21155520840662, 34.88568983762421],
+            ],
+          ],
+        ],
+      },
+    };
+
+    const singlepart = await geoblaze.sum(raster, featureCollection);
+    const multipart = await geoblaze.sum(raster, multipolygon);
+
+    // Expect the sum of the 2 polygons to be the same as the sum of the multipolygon
+    assert.equal(singlepart[0] === multipart[0], true);
+  });
+
+  test("geoblaze - compares multipolygon sum with polygon collection sum (full overlap)", async () => {
+    // Theoretically, multipolygons shouldn't overlap, but if they're made manually it might be possible
+    const url = "http://127.0.0.1:8080/data/in/feature_abyssopelagic_cog.tif";
+    const raster = await geoblaze.parse(url);
+
+    const whole = {
+      type: "Feature",
+      properties: {},
+      geometry: {
+        type: "Polygon",
+        coordinates: [
+          [
+            [-66.40706491136844, 34.283527126524476],
+            [-66.40706491136844, 33.573959204981506],
+            [-64.00596222328186, 33.58309357612872],
+            [-64.038854040927, 34.34691666832026],
+            [-66.40706491136844, 34.283527126524476],
+          ],
+        ],
+      },
+    };
+
+    const featureCollection = {
+      type: "FeatureCollection",
+      features: [
+        {
+          type: "Feature",
+          properties: {},
+          geometry: {
+            coordinates: [
+              [
+                [-66.40706491136844, 34.283527126524476],
+                [-66.40706491136844, 33.573959204981506],
+                [-64.00596222328186, 33.58309357612872],
+                [-64.038854040927, 34.34691666832026],
+                [-66.40706491136844, 34.283527126524476],
+              ],
+            ],
+
+            type: "Polygon",
+          },
+        },
+        {
+          type: "Feature",
+          properties: {},
+          geometry: {
+            coordinates: [
+              [
+                [-66.40706491136844, 34.283527126524476],
+                [-66.40706491136844, 33.573959204981506],
+                [-64.00596222328186, 33.58309357612872],
+                [-64.038854040927, 34.34691666832026],
+                [-66.40706491136844, 34.283527126524476],
+              ],
+            ],
+
+            type: "Polygon",
+          },
+        },
+      ],
+    };
+
+    const multipolygon = {
+      type: "Feature",
+      properties: {},
+      geometry: {
+        type: "MultiPolygon",
+        coordinates: [
+          [
+            [
+              [-66.40706491136844, 34.283527126524476],
+              [-66.40706491136844, 33.573959204981506],
+              [-64.00596222328186, 33.58309357612872],
+              [-64.038854040927, 34.34691666832026],
+              [-66.40706491136844, 34.283527126524476],
+            ],
+          ],
+          [
+            [
+              [-66.40706491136844, 34.283527126524476],
+              [-66.40706491136844, 33.573959204981506],
+              [-64.00596222328186, 33.58309357612872],
+              [-64.038854040927, 34.34691666832026],
+              [-66.40706491136844, 34.283527126524476],
+            ],
+          ],
+        ],
+      },
+    };
+
+    const mixedColl = {
+      type: "FeatureCollection",
+      features: [
+        {
+          type: "Feature",
+          properties: {},
+          geometry: {
+            coordinates: [
+              [
+                [-66.40706491136844, 34.283527126524476],
+                [-66.40706491136844, 33.573959204981506],
+                [-64.00596222328186, 33.58309357612872],
+                [-64.038854040927, 34.34691666832026],
+                [-66.40706491136844, 34.283527126524476],
+              ],
+            ],
+
+            type: "Polygon",
+          },
+        },
+        {
+          type: "Feature",
+          properties: {},
+          geometry: {
+            coordinates: [
+              [
+                [
+                  [-66.40706491136844, 34.283527126524476],
+                  [-66.40706491136844, 33.573959204981506],
+                  [-64.00596222328186, 33.58309357612872],
+                  [-64.038854040927, 34.34691666832026],
+                  [-66.40706491136844, 34.283527126524476],
+                ],
+              ],
+            ],
+
+            type: "MultiPolygon",
+          },
+        },
+      ],
+    };
+
+    const wholeSum = await geoblaze.sum(raster, whole);
+    const singleColl = await geoblaze.sum(raster, featureCollection);
+    const multipart = await geoblaze.sum(raster, multipolygon);
+    const mixedCollSum = await geoblaze.sum(raster, mixedColl);
+
+    // Expect the sum of the whole feature to be the same as the sum of
+    // two fully overlapping polygons (the overlap should not be counted twice)
+    // and the sum of a multipolygon with two parts which fully overlap
+    // (the overlap should not be counted twice)
+    assert.equal(
+      wholeSum[0] === singleColl[0] &&
+        singleColl[0] === multipart[0] &&
+        multipart[0] === mixedCollSum[0],
+      true
+    );
+  });
+
+  test("geoblaze - compares multipolygon sum with polygon collection sum (partial overlap)", async () => {
+    // Theoretically, multipolygons shouldn't overlap, but if they're made manually it might be possible
+    const url = "http://127.0.0.1:8080/data/in/feature_abyssopelagic_cog.tif";
+    const raster = await geoblaze.parse(url);
+
+    const whole = {
+      type: "Feature",
+      properties: {},
+      geometry: {
+        type: "Polygon",
+        coordinates: [
+          [
+            [-66.40706491136844, 34.283527126524476],
+            [-66.40706491136844, 33.573959204981506],
+            [-64.00596222328186, 33.58309357612872],
+            [-64.038854040927, 34.34691666832026],
+            [-66.40706491136844, 34.283527126524476],
+          ],
+        ],
+      },
+    };
+
+    const featureCollection = {
+      type: "FeatureCollection",
+      features: [
+        {
+          type: "Feature",
+          properties: {},
+          geometry: {
+            coordinates: [
+              [
+                [-65.81501219375808, 34.299374511973426],
+                [-65.20651356732515, 33.57852639055511],
+                [-64.00596222328186, 33.58309357612872],
+                [-64.038854040927, 34.34691666832026],
+                [-65.22295947614772, 34.31522189742237],
+                [-65.81501219375808, 34.299374511973426],
+              ],
+            ],
+
+            type: "Polygon",
+          },
+        },
+        {
+          type: "Feature",
+          properties: {},
+          geometry: {
+            coordinates: [
+              [
+                [-66.40706491136844, 34.283527126524476],
+                [-66.40706491136844, 33.573959204981506],
+                [-65.20651356732515, 33.57852639055511],
+                [-64.60623789530351, 33.580809983341915],
+                [-65.22295947614772, 34.31522189742237],
+                [-65.81501219375808, 34.299374511973426],
+                [-66.40706491136844, 34.283527126524476],
+              ],
+            ],
+
+            type: "Polygon",
+          },
+        },
+      ],
+    };
+
+    const multipolygon = {
+      type: "Feature",
+      properties: {},
+      geometry: {
+        type: "MultiPolygon",
+        coordinates: [
+          [
+            [
+              [-65.81501219375808, 34.299374511973426],
+              [-65.20651356732515, 33.57852639055511],
+              [-64.00596222328186, 33.58309357612872],
+              [-64.038854040927, 34.34691666832026],
+              [-65.22295947614772, 34.31522189742237],
+              [-65.81501219375808, 34.299374511973426],
+            ],
+          ],
+          [
+            [
+              [-66.40706491136844, 34.283527126524476],
+              [-66.40706491136844, 33.573959204981506],
+              [-65.20651356732515, 33.57852639055511],
+              [-64.60623789530351, 33.580809983341915],
+              [-65.22295947614772, 34.31522189742237],
+              [-65.81501219375808, 34.299374511973426],
+              [-66.40706491136844, 34.283527126524476],
+            ],
+          ],
+        ],
+      },
+    };
+
+    const wholeSum = await geoblaze.sum(raster, whole);
+    const singlepart = await geoblaze.sum(raster, featureCollection);
+    const multipart = await geoblaze.sum(raster, multipolygon);
+
+    // Expect the sum of the whole feature to be the same as the sum of
+    // two partially overlapping polygons (the overlap should not be counted twice)
+    // and the sum of a multipolygon with two parts which partially overlap
+    // (the overlap should not be counted twice)
+    assert.equal(
+      wholeSum[0] === singlepart[0] && singlepart[0] === multipart[0],
+      true
+    );
+  });
+
+  test("unit test across dateline and equator", async () => {
+    //  Raster   whole   2polygon & multipolygon
+    //           _____            _____
+    //  [1,1]   |     |          |_____|
+    //  [1,1]   |_____|          |_____|
+    //
+
+    const raster = await parseGeoraster(
+      [
+        [
+          [1, 1],
+          [1, 1],
+        ],
+      ],
+      {
+        noDataValue: 0,
+        projection: 4326,
+        xmin: -10, // left
+        ymax: 10, // top
+        pixelWidth: 10,
+        pixelHeight: 10,
+      }
+    );
+
+    const whole = {
+      type: "Polygon",
+      coordinates: [
+        [
+          [-9, 9],
+          [9, 9],
+          [9, -9],
+          [-9, -9],
+          [-9, 9],
+        ],
+      ],
+    };
+
+    const collection = {
+      type: "FeatureCollection",
+      features: [
+        {
+          type: "Feature",
+          properties: {},
+          geometry: {
+            coordinates: [
+              [
+                [-9, 9],
+                [9, 9],
+                [9, -1],
+                [-9, -1],
+                [-9, 9],
+              ],
+            ],
+            type: "Polygon",
+          },
+        },
+        {
+          type: "Feature",
+          properties: {},
+          geometry: {
+            coordinates: [
+              [
+                [-9, 1],
+                [9, 1],
+                [9, -9],
+                [-9, -9],
+                [-9, 1],
+              ],
+            ],
+            type: "Polygon",
+          },
+        },
+      ],
+    };
+
+    const multipolygon = {
+      type: "Feature",
+      properties: {},
+      geometry: {
+        type: "MultiPolygon",
+        coordinates: [
+          [
+            [
+              [-9, 9],
+              [9, 9],
+              [9, -1],
+              [-9, -1],
+              [-9, 9],
+            ],
+          ],
+          [
+            [
+              [-9, 1],
+              [9, 1],
+              [9, -9],
+              [-9, -9],
+              [-9, 1],
+            ],
+          ],
+        ],
+      },
+    };
+
+    const wholeSum = geoblaze.sum(raster, whole);
+    const singlepart = geoblaze.sum(raster, collection);
+    const multipart = geoblaze.sum(raster, multipolygon);
+
+    assert.equal(
+      wholeSum[0] === 4 && singlepart[0] === 4 && multipart[0] === 4,
+      true
+    );
+  });
+
+  test("simple in-memory raster unit overlap test", async () => {
+    //  Raster   whole   2polygon & multipolygon
+    //           _____            ____
+    //  [1,1]   |     |          |    | (two overlapping)
+    //  [1,1]   |_____|          |____|
+    //
+
+    const raster = await parseGeoraster(
+      [
+        [
+          [1, 1],
+          [1, 1],
+        ],
+      ],
+      {
+        noDataValue: 0,
+        projection: 4326,
+        xmin: 0, // left
+        ymax: 20, // top
+        pixelWidth: 10,
+        pixelHeight: 10,
+      }
+    );
+
+    const whole = {
+      type: "Polygon",
+      coordinates: [
+        [
+          [1, 1],
+          [1, 19],
+          [19, 19],
+          [19, 1],
+          [1, 1],
+        ],
+      ],
+    };
+
+    const collection = {
+      type: "FeatureCollection",
+      features: [
+        {
+          type: "Feature",
+          properties: {},
+          geometry: {
+            coordinates: [
+              [
+                [1, 1],
+                [1, 19],
+                [19, 19],
+                [19, 1],
+                [1, 1],
+              ],
+            ],
+
+            type: "Polygon",
+          },
+        },
+        {
+          type: "Feature",
+          properties: {},
+          geometry: {
+            coordinates: [
+              [
+                [1, 1],
+                [1, 19],
+                [19, 19],
+                [19, 1],
+                [1, 1],
+              ],
+            ],
+
+            type: "Polygon",
+          },
+        },
+      ],
+    };
+
+    const multipolygon = {
+      type: "Feature",
+      properties: {},
+      geometry: {
+        type: "MultiPolygon",
+        coordinates: [
+          [
+            [
+              [1, 1],
+              [1, 19],
+              [19, 19],
+              [19, 1],
+              [1, 1],
+            ],
+          ],
+          [
+            [
+              [1, 1],
+              [1, 19],
+              [19, 19],
+              [19, 1],
+              [1, 1],
+            ],
+          ],
+        ],
+      },
+    };
+
+    const wholeSum = geoblaze.sum(raster, whole);
+    const singlepart = geoblaze.sum(raster, collection);
+    const multipart = geoblaze.sum(raster, multipolygon);
+
+    assert.equal(
+      wholeSum[0] === 4 && singlepart[0] === 4 && multipart[0] === 4,
+      true
+    );
+  });
+});

--- a/packages/geoprocessing/src/util/withinRange.ts
+++ b/packages/geoprocessing/src/util/withinRange.ts
@@ -1,0 +1,11 @@
+/**
+ * Returns true if input1 is within deviation of input2
+ * @param input1
+ * @param input2
+ * @param deviation
+ * @returns true or false
+ */
+export function withinRange(input1: number, input2: number, deviation: number) {
+  console.log("deviations", input1, input2, Math.abs(input1 - input2));
+  return Math.abs(input1 - input2) <= deviation;
+}


### PR DESCRIPTION
Building on vitest branch, try out using node test runner for geoblaze specific tests.  Maybe there is space for this runner to be used to test code that runs in the lambdas.  It uses Tap specification so it's a lot like Tape.  Minimal, but some code modification needed from Jest/Vitest test code e.g. `expect -> assert`

Problems:

- Won't work well for React or anything that needs a dom environment to test.
- Doesn't work natively with Typescript.  Have to use a loader (tsx in this case) to transpile before being run by node
- Can't use node glob to filter directory full of typescript tests, because you have to do it up front to Typescript loader, so using glob module up front, kind of messy to put into package.json script