### PR TITLE
Support geobuf sketch parameter to geoprocessing function

### DIFF
--- a/packages/geoprocessing/src/datasources/seasketch.ts
+++ b/packages/geoprocessing/src/datasources/seasketch.ts
@@ -23,6 +23,7 @@ export const fetchGeoJSON = async <G extends Geometry>(
   Feature<G> | FeatureCollection<G> | Sketch<G> | SketchCollection<G>
 > => {
   if (request.geometryGeobuf) {
+    console.log("fetchGeoJSON, found geometryGeobuf, decoding");
     const sketchU8 = new Uint8Array(
       Buffer.from(request.geometryGeobuf, "base64")
     );

--- a/packages/geoprocessing/src/datasources/seasketch.ts
+++ b/packages/geoprocessing/src/datasources/seasketch.ts
@@ -23,7 +23,6 @@ export const fetchGeoJSON = async <G extends Geometry>(
   Feature<G> | FeatureCollection<G> | Sketch<G> | SketchCollection<G>
 > => {
   if (request.geometryGeobuf) {
-    console.log("fetchGeoJSON, found geometryGeobuf, decoding");
     const sketchU8 = new Uint8Array(
       Buffer.from(request.geometryGeobuf, "base64")
     );

--- a/packages/geoprocessing/src/datasources/seasketch.ts
+++ b/packages/geoprocessing/src/datasources/seasketch.ts
@@ -7,6 +7,8 @@ import {
   Geometry,
   GeoprocessingRequest,
 } from "../types/index.js";
+import geobuf from "geobuf";
+import Pbf from "pbf";
 import isHostedOnLambda from "./isHostedOnLambda.js";
 // Seasketch client
 
@@ -20,6 +22,16 @@ export const fetchGeoJSON = async <G extends Geometry>(
 ): Promise<
   Feature<G> | FeatureCollection<G> | Sketch<G> | SketchCollection<G>
 > => {
+  if (request.geometryGeobuf) {
+    const sketchU8 = new Uint8Array(
+      Buffer.from(request.geometryGeobuf, "base64")
+    );
+    return geobuf.decode(new Pbf(sketchU8)) as
+      | Feature<G>
+      | FeatureCollection<G>
+      | Sketch<G>
+      | SketchCollection<G>;
+  }
   if (request.geometry) {
     return request.geometry;
   } else if (request.geometryUri) {

--- a/packages/geoprocessing/src/types/service.ts
+++ b/packages/geoprocessing/src/types/service.ts
@@ -119,6 +119,8 @@ export interface GeoprocessingRequest<
   geometryUri?: string; // must be https
   /** Sketch JSON */
   geometry?: Sketch<G> | SketchCollection<G>;
+  /** Sketch Geobuf base64 string */
+  geometryGeobuf?: string;
   /** Additional runtime parameters, as escaped JSON string */
   extraParams?: string;
   token?: string;

--- a/packages/geoprocessing/src/types/service.ts
+++ b/packages/geoprocessing/src/types/service.ts
@@ -109,37 +109,18 @@ export interface PreprocessingHandlerOptions {
   requiresProperties: string[];
 }
 
-/**
- * Represents geoprocessing request via HTTP method, fully packed (stringified JSON) parameters
- */
-export interface GeoprocessingRequest<
-  G = Polygon | MultiPolygon | LineString | Point,
-> {
-  /** URL to fetch Sketch JSON */
-  geometryUri?: string; // must be https
-  /** Sketch JSON */
-  geometry?: Sketch<G> | SketchCollection<G>;
-  /** Sketch Geobuf base64 string */
-  geometryGeobuf?: string;
-  /** Additional runtime parameters, as escaped JSON string */
-  extraParams?: string;
-  token?: string;
-  cacheKey?: string;
-  wss?: string;
-  checkCacheOnly?: string;
-  onSocketConnect?: string;
-}
-
 export type GeoprocessingRequestParams = Record<string, JSONValue>;
 
 /**
- * Represents geoprocessing request internally, fully unpacked parameters
+ * Geoprocessing request internal data model, with full objects, no JSON strings
  */
 export interface GeoprocessingRequestModel<G = SketchGeometryTypes> {
   /** URL to fetch Sketch JSON */
   geometryUri?: string; // must be https
   /** Sketch JSON */
   geometry?: Sketch<G> | SketchCollection<G>;
+  /** Sketch Geobuf base64 string */
+  geometryGeobuf?: string;
   /** Additional runtime parameters */
   extraParams?: GeoprocessingRequestParams;
   token?: string;
@@ -148,6 +129,14 @@ export interface GeoprocessingRequestModel<G = SketchGeometryTypes> {
   checkCacheOnly?: string;
   onSocketConnect?: string;
 }
+
+/**
+ * Geoprocessing request sent via HTTP GET, with extraParams as url-encoded JSON string
+ */
+export type GeoprocessingRequest<G = SketchGeometryTypes> = Omit<
+  GeoprocessingRequestModel<G>,
+  "extraParams"
+> & { extraParams?: string };
 
 export interface SeaSketchReportingMessageEvent {
   client: string;


### PR DESCRIPTION
`GeoprocessingHandler` has always supported sending a sketch as GeoJSON string, directly in event payload, within the 6MB lambda limit.  This PR adds support for geometry to be sent in compact geobuf format, using an additional `geometryGeobuf` parameter, that expects a geobuf encoded as a base64 text string.  `fetchGeoJSON` now looks for and uses this parameter first, before `geometry` or `geometryUri`.