### PR TITLE
Add substacks to avoid cdk 500 resource limit

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26342,7 +26342,7 @@
       }
     },
     "packages/example-project": {
-      "version": "7.0.0-beta.4",
+      "version": "7.0.0-beta.5",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@turf/area": "7.0.0",
@@ -26357,13 +26357,14 @@
         "@turf/simplify": "7.0.0",
         "geoblaze": "2.6.1",
         "geojson-antimeridian-cut": "^0.1.0",
+        "i18next-browser-languagedetector": "^8.0.0",
         "react-i18next": "^14.1.1",
         "union-subdivided-polygons": "^0.9.1"
       },
       "devDependencies": {
         "@babel/cli": "^7.24.5",
         "@babel/plugin-syntax-import-attributes": "^7.24.1",
-        "@seasketch/geoprocessing": "^7.0.0-beta.4",
+        "@seasketch/geoprocessing": "7.0.0-beta.5",
         "@storybook/addon-essentials": "^8.1.1",
         "@storybook/addon-interactions": "^8.1.1",
         "@storybook/addon-links": "^8.1.1",

--- a/packages/geoprocessing/scripts/aws/GeoprocessingStack.ts
+++ b/packages/geoprocessing/scripts/aws/GeoprocessingStack.ts
@@ -77,22 +77,14 @@ export class GeoprocessingStack extends Stack {
     this.props = props;
 
     // Create lambda functions
-    this.syncLambdaStack = new LambdaStack(
-      this,
-      `${this.props.projectName}-sync-fns`,
-      {
-        ...props,
-        type: "sync",
-      }
-    );
-    this.asyncLambdaStack = new LambdaStack(
-      this,
-      `${this.props.projectName}-async-fns`,
-      {
-        ...props,
-        type: "async",
-      }
-    );
+    this.syncLambdaStack = new LambdaStack(this, `sync-fns`, {
+      ...props,
+      type: "sync",
+    });
+    this.asyncLambdaStack = new LambdaStack(this, `async-fns`, {
+      ...props,
+      type: "async",
+    });
 
     // Create other functions root/socket
     this.functions = createFunctions(this);

--- a/packages/geoprocessing/scripts/aws/GeoprocessingStack.ts
+++ b/packages/geoprocessing/scripts/aws/GeoprocessingStack.ts
@@ -77,14 +77,22 @@ export class GeoprocessingStack extends Stack {
     this.props = props;
 
     // Create lambda functions
-    this.syncLambdaStack = new LambdaStack(this, id + "-sync-fns", {
-      ...props,
-      type: "sync",
-    });
-    this.asyncLambdaStack = new LambdaStack(this, id + "-async-fns", {
-      ...props,
-      type: "async",
-    });
+    this.syncLambdaStack = new LambdaStack(
+      this,
+      `${this.props.projectName}-sync-fns`,
+      {
+        ...props,
+        type: "sync",
+      }
+    );
+    this.asyncLambdaStack = new LambdaStack(
+      this,
+      `${this.props.projectName}-async-fns`,
+      {
+        ...props,
+        type: "async",
+      }
+    );
 
     // Create other functions root/socket
     this.functions = createFunctions(this);

--- a/packages/geoprocessing/scripts/aws/GeoprocessingStack.ts
+++ b/packages/geoprocessing/scripts/aws/GeoprocessingStack.ts
@@ -77,11 +77,11 @@ export class GeoprocessingStack extends Stack {
     this.props = props;
 
     // Create lambda functions
-    this.syncLambdaStack = new LambdaStack(this, `${id}-sync-fns`, {
+    this.syncLambdaStack = new LambdaStack(this, `sync-fns`, {
       ...props,
       type: "sync",
     });
-    this.asyncLambdaStack = new LambdaStack(this, `${id}-async-fns`, {
+    this.asyncLambdaStack = new LambdaStack(this, `async-fns`, {
       ...props,
       type: "async",
     });

--- a/packages/geoprocessing/scripts/aws/GeoprocessingStack.ts
+++ b/packages/geoprocessing/scripts/aws/GeoprocessingStack.ts
@@ -77,11 +77,11 @@ export class GeoprocessingStack extends Stack {
     this.props = props;
 
     // Create lambda functions
-    this.syncLambdaStack = new LambdaStack(this, `sync-fns`, {
+    this.syncLambdaStack = new LambdaStack(this, `${id}-sync-fns`, {
       ...props,
       type: "sync",
     });
-    this.asyncLambdaStack = new LambdaStack(this, `async-fns`, {
+    this.asyncLambdaStack = new LambdaStack(this, `${id}-async-fns`, {
       ...props,
       type: "async",
     });

--- a/packages/geoprocessing/scripts/aws/LambdaStack.ts
+++ b/packages/geoprocessing/scripts/aws/LambdaStack.ts
@@ -1,4 +1,4 @@
-import { NestedStack, NestedStackProps, CfnElement } from "aws-cdk-lib";
+import { NestedStack, NestedStackProps } from "aws-cdk-lib";
 import { Construct } from "constructs";
 import {
   Manifest,
@@ -51,15 +51,6 @@ export class LambdaStack extends NestedStack {
 
     // Create lambdas for all functions
     this.processingFunctions = this.createProcessingFunctions();
-  }
-
-  // Force stack name to be same as logical ID, otherwise it generates a very long cryptic one
-  // https://github.com/aws/aws-cdk/issues/18053#issuecomment-1272927543
-  getLogicalId(element: CfnElement): string {
-    if (element.node.id.includes("NestedStackResource")) {
-      return /([a-zA-Z0-9]+)\.NestedStackResource/.exec(element.node.id)![1]; // will be the exact id of the stack
-    }
-    return super.getLogicalId(element);
   }
 
   getProcessingFunctions() {

--- a/packages/geoprocessing/scripts/aws/LambdaStack.ts
+++ b/packages/geoprocessing/scripts/aws/LambdaStack.ts
@@ -1,0 +1,225 @@
+import { NestedStack, NestedStackProps } from "aws-cdk-lib";
+import { Construct } from "constructs";
+import {
+  Manifest,
+  GeoprocessingFunctionMetadata,
+  ProcessingFunctionMetadata,
+} from "../manifest.js";
+import {
+  ProcessingFunctions,
+  AsyncFunctionWithMeta,
+  SyncFunctionWithMeta,
+} from "./types.js";
+import { Duration } from "aws-cdk-lib";
+import { Function, Code } from "aws-cdk-lib/aws-lambda";
+import {
+  Effect,
+  PolicyStatement,
+  Role,
+  ServicePrincipal,
+} from "aws-cdk-lib/aws-iam";
+
+import config from "./config.js";
+import path from "path";
+
+export interface GeoprocessingNestedStackProps extends NestedStackProps {
+  projectName: string;
+  projectPath: string;
+  manifest: Manifest;
+}
+
+// Once sync functions create, contains policies to invoke all sync functions
+const invokeSyncLambdaPolicies: PolicyStatement[] = [];
+
+export class LambdaStack extends NestedStack {
+  props: GeoprocessingNestedStackProps;
+  processingFunctions: ProcessingFunctions;
+
+  constructor(
+    scope: Construct,
+    id: string,
+    props: GeoprocessingNestedStackProps
+  ) {
+    super(scope, id + "-fns", props);
+    this.props = props;
+
+    // Create lambdas for all functions
+    this.processingFunctions = this.createProcessingFunctions();
+  }
+
+  getProcessingFunctions() {
+    return this.processingFunctions;
+  }
+
+  /**
+   * Create Lambda function constructs
+   */
+  createProcessingFunctions = (): ProcessingFunctions => {
+    return [...this.createSyncFunctions(), ...this.createAsyncFunctions()];
+  };
+
+  /** Create Lambda function constructs for sync functions that return result immediately */
+  private createSyncFunctions = (): SyncFunctionWithMeta[] => {
+    const syncFunctionMetas: ProcessingFunctionMetadata[] = [
+      ...this.props.manifest.preprocessingFunctions,
+      ...this.props.manifest.geoprocessingFunctions.filter(
+        (func) => func.executionMode === "sync"
+      ),
+    ];
+
+    return syncFunctionMetas.map(
+      (functionMeta: ProcessingFunctionMetadata, index: number) => {
+        const rootPointer = getHandlerPointer(functionMeta);
+        const pkgName = getHandlerPkgName(functionMeta);
+        const functionName = `gp-${this.props.projectName}-sync-${functionMeta.title}`;
+        const codePath = path.join(this.props.projectPath, ".build", pkgName);
+        // console.log("codePath", codePath);
+        // console.log("rootPointer", rootPointer);
+
+        const func = new Function(this, `${functionMeta.title}GpSyncHandler`, {
+          runtime: config.NODE_RUNTIME,
+          code: Code.fromAsset(codePath),
+          handler: rootPointer,
+          functionName,
+          memorySize: functionMeta.memory,
+          timeout: Duration.seconds(
+            functionMeta.timeout || config.SYNC_LAMBDA_TIMEOUT
+          ),
+          description: functionMeta.description,
+        });
+
+        // Allow sync functions to invoked by other functions
+        const syncInvokeLambdaPolicy = new PolicyStatement({
+          effect: Effect.ALLOW,
+          resources: [func.functionArn],
+          actions: ["lambda:InvokeFunction"],
+        });
+        invokeSyncLambdaPolicies.push(syncInvokeLambdaPolicy);
+
+        return {
+          func,
+          meta: functionMeta,
+        };
+      }
+    );
+  };
+
+  /** Create Lambda function constructs for functions that return result async */
+  private createAsyncFunctions = (): AsyncFunctionWithMeta[] => {
+    const asyncFunctionMetas =
+      this.props.manifest.geoprocessingFunctions.filter(
+        (func) =>
+          func.executionMode === "async" && func.purpose !== "preprocessing"
+      );
+
+    return asyncFunctionMetas.map(
+      (functionMeta: GeoprocessingFunctionMetadata, index: number) => {
+        const rootPointer = getHandlerPointer(functionMeta);
+        const pkgName = getHandlerPkgName(functionMeta);
+        const startFunctionName = `gp-${this.props.projectName}-async-${functionMeta.title}-start`;
+        const runFunctionName = `gp-${this.props.projectName}-async-${functionMeta.title}-run`;
+
+        /**
+         * startHandler Lambda is connected to the REST API allowing client to
+         * start a GP function task, which invokes the runHandler Lambda
+         */
+        const startFunc = new Function(
+          this,
+          `${functionMeta.title}GpAsyncHandlerStart`,
+          {
+            runtime: config.NODE_RUNTIME,
+            code: Code.fromAsset(
+              path.join(this.props.projectPath, ".build", pkgName)
+            ),
+            handler: rootPointer,
+            functionName: startFunctionName,
+            memorySize: functionMeta.memory,
+            timeout: Duration.seconds(config.ASYNC_LAMBDA_START_TIMEOUT),
+            description: functionMeta.description,
+            environment: {
+              ASYNC_REQUEST_TYPE: "start",
+              RUN_HANDLER_FUNCTION_NAME: runFunctionName,
+            },
+          }
+        );
+
+        /**
+         * runHandler Lambda is invoked by startHandler Lambda
+         * Used for running GP function and reporting back results async via socket
+         */
+        const runFunc = new Function(
+          this,
+          `${functionMeta.title}GpAsyncHandlerRun`,
+          {
+            runtime: config.NODE_RUNTIME,
+            code: Code.fromAsset(
+              path.join(this.props.projectPath, ".build", pkgName)
+            ),
+
+            handler: rootPointer,
+            functionName: runFunctionName,
+            memorySize: functionMeta.memory,
+            timeout: Duration.seconds(
+              functionMeta.timeout || config.ASYNC_LAMBDA_RUN_TIMEOUT
+            ),
+            description: functionMeta.description,
+            environment: {
+              ASYNC_REQUEST_TYPE: "run",
+            },
+          }
+        );
+
+        // Allow start function to invoke run function
+        const invokeAsyncRunLambdaPolicy = new PolicyStatement({
+          effect: Effect.ALLOW,
+          resources: [runFunc.functionArn],
+          actions: ["lambda:InvokeFunction"],
+        });
+        const asyncLambdaRole = new Role(this, "GpAsyncLambdaRole" + index, {
+          assumedBy: new ServicePrincipal("lambda.amazonaws.com"),
+        });
+        asyncLambdaRole.addToPolicy(invokeAsyncRunLambdaPolicy);
+        startFunc.addToRolePolicy(invokeAsyncRunLambdaPolicy);
+
+        // Allow async lambdas to invoke sync lambdas (workers)
+        invokeSyncLambdaPolicies.forEach(
+          (curInvokeSyncLambdaPolicy, index2) => {
+            const syncLambdaRole = new Role(
+              this,
+              "GpSyncLambdaRole" + index + "_" + index2,
+              {
+                assumedBy: new ServicePrincipal("lambda.amazonaws.com"),
+              }
+            );
+            syncLambdaRole.addToPolicy(curInvokeSyncLambdaPolicy);
+            runFunc.addToRolePolicy(curInvokeSyncLambdaPolicy);
+          }
+        );
+
+        return {
+          startFunc,
+          runFunc,
+          meta: functionMeta,
+        };
+      }
+    );
+  };
+}
+
+/**
+ * Returns root lambda handler method pointer in module.function dot notation
+ */
+export function getHandlerPointer(funcMeta: ProcessingFunctionMetadata) {
+  return `${funcMeta.handlerFilename
+    .replace(/\.js$/, "")
+    .replace(/\.ts$/, "")}Handler.handler`;
+}
+
+/**
+ * Returns build package name to look for handler
+ */
+export function getHandlerPkgName(funcMeta: ProcessingFunctionMetadata) {
+  return `${funcMeta.handlerFilename
+    .replace(/\.js$/, "")
+    .replace(/\.ts$/, "")}`;
+}

--- a/packages/geoprocessing/scripts/aws/LambdaStack.ts
+++ b/packages/geoprocessing/scripts/aws/LambdaStack.ts
@@ -1,4 +1,4 @@
-import { NestedStack, NestedStackProps } from "aws-cdk-lib";
+import { NestedStack, NestedStackProps, CfnElement } from "aws-cdk-lib";
 import { Construct } from "constructs";
 import {
   Manifest,
@@ -51,6 +51,15 @@ export class LambdaStack extends NestedStack {
 
     // Create lambdas for all functions
     this.processingFunctions = this.createProcessingFunctions();
+  }
+
+  // Force stack name to be same as logical ID, otherwise it generates a very long cryptic one
+  // https://github.com/aws/aws-cdk/issues/18053#issuecomment-1272927543
+  getLogicalId(element: CfnElement): string {
+    if (element.node.id.includes("NestedStackResource")) {
+      return /([a-zA-Z0-9]+)\.NestedStackResource/.exec(element.node.id)![1]; // will be the exact id of the stack
+    }
+    return super.getLogicalId(element);
   }
 
   getProcessingFunctions() {

--- a/packages/geoprocessing/scripts/aws/dynamodb.ts
+++ b/packages/geoprocessing/scripts/aws/dynamodb.ts
@@ -13,7 +13,7 @@ export const createTables = (stack: GeoprocessingStack): GpDynamoTables => {
     estimates: undefined,
     subscriptions: undefined,
   };
-  if (stack.functions.processingFunctions.length > 0) {
+  if (stack.lambdaStack.getProcessingFunctions().length > 0) {
     tables.tasks = new Table(stack, `GpTasksTable`, {
       partitionKey: { name: "id", type: AttributeType.STRING },
       sortKey: { name: "service", type: AttributeType.STRING },

--- a/packages/geoprocessing/scripts/aws/dynamodb.ts
+++ b/packages/geoprocessing/scripts/aws/dynamodb.ts
@@ -13,7 +13,7 @@ export const createTables = (stack: GeoprocessingStack): GpDynamoTables => {
     estimates: undefined,
     subscriptions: undefined,
   };
-  if (stack.lambdaStack.getProcessingFunctions().length > 0) {
+  if (stack.getProcessingFunctions().length > 0) {
     tables.tasks = new Table(stack, `GpTasksTable`, {
       partitionKey: { name: "id", type: AttributeType.STRING },
       sortKey: { name: "service", type: AttributeType.STRING },

--- a/packages/geoprocessing/scripts/aws/functionResources.ts
+++ b/packages/geoprocessing/scripts/aws/functionResources.ts
@@ -1,17 +1,5 @@
 import { GeoprocessingStack } from "./GeoprocessingStack.js";
-import { Duration } from "aws-cdk-lib";
 import { Function, Code } from "aws-cdk-lib/aws-lambda";
-import {
-  Effect,
-  PolicyStatement,
-  Role,
-  ServicePrincipal,
-} from "aws-cdk-lib/aws-iam";
-import { SyncFunctionWithMeta, AsyncFunctionWithMeta } from "./types.js";
-import {
-  ProcessingFunctionMetadata,
-  GeoprocessingFunctionMetadata,
-} from "../manifest.js";
 
 import config from "./config.js";
 import {
@@ -28,11 +16,6 @@ export interface CreateFunctionOptions {
 }
 import path from "path";
 
-const GP_ROOT = process.env.GP_ROOT;
-
-// Once sync functions create, contains policies to invoke all sync functions
-const invokeSyncLambdaPolicies: PolicyStatement[] = [];
-
 /**
  * Create Lambda function constructs
  */
@@ -42,10 +25,6 @@ export const createFunctions = (
   return {
     serviceRootFunction: createRootFunction(stack),
     socketFunctions: createSocketFunctions(stack),
-    processingFunctions: [
-      ...createSyncFunctions(stack),
-      ...createAsyncFunctions(stack),
-    ],
   };
 };
 
@@ -115,168 +94,3 @@ export const createSocketFunctions = (
 
   return socketFunctions;
 };
-
-/** Create Lambda function constructs for sync functions that return result immediately */
-const createSyncFunctions = (
-  stack: GeoprocessingStack
-): SyncFunctionWithMeta[] => {
-  const syncFunctionMetas: ProcessingFunctionMetadata[] = [
-    ...stack.props.manifest.preprocessingFunctions,
-    ...stack.props.manifest.geoprocessingFunctions.filter(
-      (func) => func.executionMode === "sync"
-    ),
-  ];
-
-  return syncFunctionMetas.map(
-    (functionMeta: ProcessingFunctionMetadata, index: number) => {
-      const rootPointer = getHandlerPointer(functionMeta);
-      const pkgName = getHandlerPkgName(functionMeta);
-      const functionName = `gp-${stack.props.projectName}-sync-${functionMeta.title}`;
-      const codePath = path.join(stack.props.projectPath, ".build", pkgName);
-      // console.log("codePath", codePath);
-      // console.log("rootPointer", rootPointer);
-
-      const func = new Function(stack, `${functionMeta.title}GpSyncHandler`, {
-        runtime: config.NODE_RUNTIME,
-        code: Code.fromAsset(codePath),
-        handler: rootPointer,
-        functionName,
-        memorySize: functionMeta.memory,
-        timeout: Duration.seconds(
-          functionMeta.timeout || config.SYNC_LAMBDA_TIMEOUT
-        ),
-        description: functionMeta.description,
-      });
-
-      // Allow sync functions to invoked by other functions
-      const syncInvokeLambdaPolicy = new PolicyStatement({
-        effect: Effect.ALLOW,
-        resources: [func.functionArn],
-        actions: ["lambda:InvokeFunction"],
-      });
-      invokeSyncLambdaPolicies.push(syncInvokeLambdaPolicy);
-
-      return {
-        func,
-        meta: functionMeta,
-      };
-    }
-  );
-};
-
-/** Create Lambda function constructs for functions that return result async */
-const createAsyncFunctions = (
-  stack: GeoprocessingStack
-): AsyncFunctionWithMeta[] => {
-  const asyncFunctionMetas = stack.props.manifest.geoprocessingFunctions.filter(
-    (func) => func.executionMode === "async" && func.purpose !== "preprocessing"
-  );
-
-  return asyncFunctionMetas.map(
-    (functionMeta: GeoprocessingFunctionMetadata, index: number) => {
-      const rootPointer = getHandlerPointer(functionMeta);
-      const pkgName = getHandlerPkgName(functionMeta);
-      const startFunctionName = `gp-${stack.props.projectName}-async-${functionMeta.title}-start`;
-      const runFunctionName = `gp-${stack.props.projectName}-async-${functionMeta.title}-run`;
-
-      /**
-       * startHandler Lambda is connected to the REST API allowing client to
-       * start a GP function task, which invokes the runHandler Lambda
-       */
-      const startFunc = new Function(
-        stack,
-        `${functionMeta.title}GpAsyncHandlerStart`,
-        {
-          runtime: config.NODE_RUNTIME,
-          code: Code.fromAsset(
-            path.join(stack.props.projectPath, ".build", pkgName)
-          ),
-          handler: rootPointer,
-          functionName: startFunctionName,
-          memorySize: functionMeta.memory,
-          timeout: Duration.seconds(config.ASYNC_LAMBDA_START_TIMEOUT),
-          description: functionMeta.description,
-          environment: {
-            ASYNC_REQUEST_TYPE: "start",
-            RUN_HANDLER_FUNCTION_NAME: runFunctionName,
-          },
-        }
-      );
-
-      /**
-       * runHandler Lambda is invoked by startHandler Lambda
-       * Used for running GP function and reporting back results async via socket
-       */
-      const runFunc = new Function(
-        stack,
-        `${functionMeta.title}GpAsyncHandlerRun`,
-        {
-          runtime: config.NODE_RUNTIME,
-          code: Code.fromAsset(
-            path.join(stack.props.projectPath, ".build", pkgName)
-          ),
-
-          handler: rootPointer,
-          functionName: runFunctionName,
-          memorySize: functionMeta.memory,
-          timeout: Duration.seconds(
-            functionMeta.timeout || config.ASYNC_LAMBDA_RUN_TIMEOUT
-          ),
-          description: functionMeta.description,
-          environment: {
-            ASYNC_REQUEST_TYPE: "run",
-          },
-        }
-      );
-
-      // Allow start function to invoke run function
-      const invokeAsyncRunLambdaPolicy = new PolicyStatement({
-        effect: Effect.ALLOW,
-        resources: [runFunc.functionArn],
-        actions: ["lambda:InvokeFunction"],
-      });
-      const asyncLambdaRole = new Role(stack, "GpAsyncLambdaRole" + index, {
-        assumedBy: new ServicePrincipal("lambda.amazonaws.com"),
-      });
-      asyncLambdaRole.addToPolicy(invokeAsyncRunLambdaPolicy);
-      startFunc.addToRolePolicy(invokeAsyncRunLambdaPolicy);
-
-      // Allow async lambdas to invoke sync lambdas (workers)
-      invokeSyncLambdaPolicies.forEach((curInvokeSyncLambdaPolicy, index2) => {
-        const syncLambdaRole = new Role(
-          stack,
-          "GpSyncLambdaRole" + index + "_" + index2,
-          {
-            assumedBy: new ServicePrincipal("lambda.amazonaws.com"),
-          }
-        );
-        syncLambdaRole.addToPolicy(curInvokeSyncLambdaPolicy);
-        runFunc.addToRolePolicy(curInvokeSyncLambdaPolicy);
-      });
-
-      return {
-        startFunc,
-        runFunc,
-        meta: functionMeta,
-      };
-    }
-  );
-};
-
-/**
- * Returns root lambda handler method pointer in module.function dot notation
- */
-export function getHandlerPointer(funcMeta: ProcessingFunctionMetadata) {
-  return `${funcMeta.handlerFilename
-    .replace(/\.js$/, "")
-    .replace(/\.ts$/, "")}Handler.handler`;
-}
-
-/**
- * Returns build package name to look for handler
- */
-export function getHandlerPkgName(funcMeta: ProcessingFunctionMetadata) {
-  return `${funcMeta.handlerFilename
-    .replace(/\.js$/, "")
-    .replace(/\.ts$/, "")}`;
-}

--- a/packages/geoprocessing/scripts/aws/publicBuckets.ts
+++ b/packages/geoprocessing/scripts/aws/publicBuckets.ts
@@ -32,7 +32,7 @@ export const createPublicBuckets = (
     }),
   };
 
-  if (stack.functions.processingFunctions.length > 0) {
+  if (stack.lambdaStack.getProcessingFunctions.length > 0) {
     const result = new Bucket(stack, `GpResultBucket`, {
       bucketName: `gp-${stack.props.projectName}-results`,
       versioned: false,

--- a/packages/geoprocessing/scripts/aws/publicBuckets.ts
+++ b/packages/geoprocessing/scripts/aws/publicBuckets.ts
@@ -32,7 +32,7 @@ export const createPublicBuckets = (
     }),
   };
 
-  if (stack.lambdaStack.getProcessingFunctions.length > 0) {
+  if (stack.getProcessingFunctions().length > 0) {
     const result = new Bucket(stack, `GpResultBucket`, {
       bucketName: `gp-${stack.props.projectName}-results`,
       versioned: false,

--- a/packages/geoprocessing/scripts/aws/types.ts
+++ b/packages/geoprocessing/scripts/aws/types.ts
@@ -24,6 +24,11 @@ export interface AsyncFunctionWithMeta {
   runFunc: Function;
 }
 
+export type ProcessingFunctions = (
+  | SyncFunctionWithMeta
+  | AsyncFunctionWithMeta
+)[];
+
 /**
  * Catch-all type for gp function lambda paired with metadata
  */
@@ -69,6 +74,4 @@ export interface GpProjectFunctions {
   serviceRootFunction: Function;
   /** Base web socket functions */
   socketFunctions: GpSocketFunctions;
-  /** geoprocessing/preprocessing functions */
-  processingFunctions: (SyncFunctionWithMeta | AsyncFunctionWithMeta)[];
 }

--- a/packages/geoprocessing/src/toolbox/overlapFeatures.test.ts
+++ b/packages/geoprocessing/src/toolbox/overlapFeatures.test.ts
@@ -5,6 +5,8 @@ import fix from "../testing/fixtures/squareSketches.js";
 import sk from "../testing/fixtures/sketches.js";
 import { firstMatchingMetric } from "../metrics/index.js";
 import { testWithinPerc } from "../testing/index.js";
+import { Sketch } from "../types/sketch.js";
+import { FeatureCollection, MultiPolygon, Polygon } from "geojson";
 
 describe("overlapFeatures", () => {
   test("function is present", () => {
@@ -77,6 +79,30 @@ describe("overlapFeatures", () => {
     const areaOf2 = area(fix.sketch2);
     const percDiff = (metrics[0].value / (areaOf2 * 0.5)) % 1;
     expect(percDiff).toBeCloseTo(0);
+  });
+
+  test("overlapFeatures - should not count holes", async () => {
+    console.log(JSON.stringify(sk.holeBlPoly));
+    const metrics = await overlapFeatures(
+      "test",
+      [sk.wholePoly],
+      sk.holeBlPoly
+    );
+
+    // 3487699295400.2056 qgis area result
+    // 3473074014471.342  turf is close
+
+    expect(metrics.length).toEqual(1);
+    const wholeArea = area(sk.wholePoly);
+    console.log("wholeArea", wholeArea);
+    const holeArea = area(sk.holeBlPoly);
+    console.log("holeArea", holeArea);
+    const overlapArea = metrics[0].value;
+    console.log("overlapArea", overlapArea);
+    const percDiff = Math.abs(overlapArea - holeArea) / holeArea;
+    console.log("percDiff", percDiff);
+    expect(percDiff).toBeGreaterThan(0);
+    expect(percDiff).toBeLessThan(1);
   });
 
   test("overlapFeatures - sketch polygon fully outside", async () => {


### PR DESCRIPTION
Only goes as far as splitting into two lambda nested stacks - sync and async.  In practice, it is overweight on async.  A better strategy is needed, probably a scalable number of nested stacks, more getting added as they are outgrown.