### PR TITLE
Handle no-overlap for categorical rasters

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12734,10 +12734,6 @@
         "safe-buffer": "^5.1.1"
       }
     },
-    "node_modules/example-project": {
-      "resolved": "packages/example-project",
-      "link": true
-    },
     "node_modules/execa": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
@@ -26343,6 +26339,7 @@
     },
     "packages/example-project": {
       "version": "7.0.0-beta.5",
+      "extraneous": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "@turf/area": "7.0.0",

--- a/packages/geoprocessing/scripts/base/datasources/precalcRasterDatasource.ts
+++ b/packages/geoprocessing/scripts/base/datasources/precalcRasterDatasource.ts
@@ -1,5 +1,4 @@
 import {
-  Histogram,
   Georaster,
   Metric,
   Geography,

--- a/packages/geoprocessing/src/toolbox/geoblaze/geoblaze.ts
+++ b/packages/geoprocessing/src/toolbox/geoblaze/geoblaze.ts
@@ -11,7 +11,8 @@ import reprojectGeoJSONPlugable from "reproject-geojson/pluggable.js";
 import proj4 from "../proj4.js";
 import bboxFns from "bbox-fns";
 
-export const defaultStatValues = {
+// default values for stats calculated by geoblaze.stats
+export const geoblazeDefaultStatValues = {
   count: 0,
   invalid: 0,
   max: null,

--- a/packages/geoprocessing/src/toolbox/geoblaze/rasterStats.test.e2e.ts
+++ b/packages/geoprocessing/src/toolbox/geoblaze/rasterStats.test.e2e.ts
@@ -127,4 +127,92 @@ describe("rasterStats", () => {
     });
     // should return zero values for each stat if no feature overlap
   });
+
+  test("rasterStats -  categorical", async () => {
+    const raster = await parseGeoraster(
+      [
+        [
+          [1, 2],
+          [0, 1],
+        ],
+      ],
+      {
+        noDataValue: 0,
+        projection: 4326,
+        xmin: 0, // left
+        ymax: 20, // top
+        pixelWidth: 10,
+        pixelHeight: 10,
+      }
+    );
+
+    const statsByBand = await rasterStats(raster, {
+      categorical: true,
+    });
+    const stats = statsByBand[0];
+    const statNames = Object.keys(stats);
+    expect(statNames.length).toEqual(1);
+    expect(statNames[0]).toBe("histogram");
+    expect(stats[statNames[0]][1]).toBe(2);
+    expect(stats[statNames[0]][2]).toBe(1);
+  });
+
+  test("rasterStats - non-overlapping feature categorical", async () => {
+    const raster = await parseGeoraster(
+      [
+        [
+          [1, 2],
+          [0, 1],
+        ],
+      ],
+      {
+        noDataValue: 0,
+        projection: 4326,
+        xmin: 0, // left
+        ymax: 20, // top
+        pixelWidth: 10,
+        pixelHeight: 10,
+      }
+    );
+
+    const statsByBand = await rasterStats(raster, {
+      feature: testData.outsideQuadPoly,
+      categorical: true,
+    });
+    const stats = statsByBand[0];
+    const statNames = Object.keys(stats);
+    expect(statNames.length).toEqual(1);
+    expect(statNames[0]).toBe("histogram");
+    expect(stats[statNames[0]]).toStrictEqual({});
+  });
+
+  test("rasterStats - non-overlapping feature categorical return 0", async () => {
+    const raster = await parseGeoraster(
+      [
+        [
+          [1, 2],
+          [0, 1],
+        ],
+      ],
+      {
+        noDataValue: 0,
+        projection: 4326,
+        xmin: 0, // left
+        ymax: 20, // top
+        pixelWidth: 10,
+        pixelHeight: 10,
+      }
+    );
+
+    const statsByBand = await rasterStats(raster, {
+      feature: testData.outsideQuadPoly,
+      categorical: true,
+      categoryMetricValues: ["1"],
+    });
+    const stats = statsByBand[0];
+    const statNames = Object.keys(stats);
+    expect(statNames.length).toEqual(1);
+    expect(statNames[0]).toBe("histogram");
+    expect(stats[statNames[0]][1]).toStrictEqual(0);
+  });
 });

--- a/packages/geoprocessing/src/toolbox/geoblaze/rasterStats.test.e2e.ts
+++ b/packages/geoprocessing/src/toolbox/geoblaze/rasterStats.test.e2e.ts
@@ -1,10 +1,9 @@
 import { describe, test, expect } from "vitest";
-import { rasterStats } from "./rasterStats.js";
+import { rasterStats, defaultStatValues } from "./rasterStats.js";
 //@ts-ignore
 import geoblaze from "geoblaze";
 import testData from "./test/testData.js";
 import parseGeoraster from "georaster";
-import { defaultStatValues } from "./geoblaze.js";
 
 describe("rasterStats", () => {
   test("rasterStats - default sum", async () => {
@@ -183,7 +182,7 @@ describe("rasterStats", () => {
     const statNames = Object.keys(stats);
     expect(statNames.length).toEqual(1);
     expect(statNames[0]).toBe("histogram");
-    expect(stats[statNames[0]]).toStrictEqual({});
+    expect(stats[statNames[0]]).toStrictEqual(defaultStatValues.histogram);
   });
 
   test("rasterStats - non-overlapping feature categorical return 0", async () => {

--- a/packages/geoprocessing/src/toolbox/overlapRasterClass.ts
+++ b/packages/geoprocessing/src/toolbox/overlapRasterClass.ts
@@ -9,7 +9,7 @@ import {
 } from "../types/index.js";
 import { isSketchCollection } from "../helpers/index.js";
 import { createMetric } from "../metrics/index.js";
-import { Histogram } from "../types/georaster.js";
+import { Histogram } from "../types/geoblaze.js";
 import { getHistogram } from "./geoblaze/index.js";
 import { featureEach } from "@turf/meta";
 

--- a/packages/geoprocessing/src/types/geoblaze.ts
+++ b/packages/geoprocessing/src/types/geoblaze.ts
@@ -24,18 +24,18 @@ export const GEOBLAZE_RASTER_STATS: ReadonlyArray<string> = [
   "std",
   "variance",
 ];
-export type GEOBLAZE_RASTER_STAT = typeof GEOBLAZE_RASTER_STATS[number];
+export type GEOBLAZE_RASTER_STAT = (typeof GEOBLAZE_RASTER_STATS)[number];
 
 /** Additional raster stats calculated by geoprocessing library */
 export const EXTRA_RASTER_STATS: ReadonlyArray<string> = ["area", "histogram"];
-export type EXTRA_RASTER_STAT = typeof EXTRA_RASTER_STATS[number];
+export type EXTRA_RASTER_STAT = (typeof EXTRA_RASTER_STATS)[number];
 
 /** Combined raster stats supported by geoprocessing library */
 export const SUPPORTED_RASTER_STATS: ReadonlyArray<string> = [
   ...GEOBLAZE_RASTER_STATS,
   ...EXTRA_RASTER_STATS,
 ];
-export type SUPPORTED_RASTER_STAT = typeof SUPPORTED_RASTER_STATS[number];
+export type SUPPORTED_RASTER_STAT = (typeof SUPPORTED_RASTER_STATS)[number];
 
 export interface StatsObject {
   /** Number of cells that are not nodata */
@@ -64,6 +64,8 @@ export interface StatsObject {
   std?: Nullable<number>;
   /** Statistical measurement of spread between values in raster */
   variance?: Nullable<number>;
+  /** Histogram only for categorical raster */
+  histogram?: Nullable<{}>;
 }
 
 /**

--- a/packages/geoprocessing/src/types/geoblaze.ts
+++ b/packages/geoprocessing/src/types/geoblaze.ts
@@ -64,7 +64,7 @@ export interface StatsObject {
   std?: Nullable<number>;
   /** Statistical measurement of spread between values in raster */
   variance?: Nullable<number>;
-  /** Histogram only for categorical raster */
+  /** Histogram object, for categorical raster, mapping category IDs to cell count */
   histogram?: Nullable<{}>;
 }
 
@@ -83,7 +83,7 @@ export interface CalcStatsOptions {
   filter?: (index: number, value: number) => boolean;
 }
 
-interface HistogramOptions {
+export interface HistogramOptions {
   scaleType: "nominal" | "ratio";
   /** required for ratio scaleType */
   numClasses?: number;
@@ -91,7 +91,7 @@ interface HistogramOptions {
   classType?: "equal-interval" | "quantile";
 }
 
-interface Histogram {
+export interface Histogram {
   [binKey: string]: number;
 }
 

--- a/packages/geoprocessing/src/types/georaster.ts
+++ b/packages/geoprocessing/src/types/georaster.ts
@@ -81,7 +81,3 @@ export type GeorasterMetadata = Pick<
   Georaster,
   "noDataValue" | "projection" | "xmin" | "ymax" | "pixelWidth" | "pixelHeight"
 >;
-
-export interface Histogram {
-  [classId: string]: number;
-}


### PR DESCRIPTION
rasterStats would empty histograms when no overlap was present. Updates rasterStats to return valid histogram metrics for all `categoryMetricValues`. Tested in california-reports