### PR TITLE
Categorical raster PR improve

### DIFF
--- a/packages/geoprocessing/scripts/base/datasources/precalcRasterDatasource.ts
+++ b/packages/geoprocessing/scripts/base/datasources/precalcRasterDatasource.ts
@@ -1,5 +1,4 @@
 import {
-  Histogram,
   Georaster,
   Metric,
   Geography,

--- a/packages/geoprocessing/src/toolbox/geoblaze/geoblaze.ts
+++ b/packages/geoprocessing/src/toolbox/geoblaze/geoblaze.ts
@@ -11,7 +11,8 @@ import reprojectGeoJSONPlugable from "reproject-geojson/pluggable.js";
 import proj4 from "../proj4.js";
 import bboxFns from "bbox-fns";
 
-export const defaultStatValues = {
+// default values for stats calculated by geoblaze.stats
+export const geoblazeDefaultStatValues = {
   count: 0,
   invalid: 0,
   max: null,

--- a/packages/geoprocessing/src/toolbox/geoblaze/rasterStats.test.e2e.ts
+++ b/packages/geoprocessing/src/toolbox/geoblaze/rasterStats.test.e2e.ts
@@ -182,7 +182,7 @@ describe("rasterStats", () => {
     const statNames = Object.keys(stats);
     expect(statNames.length).toEqual(1);
     expect(statNames[0]).toBe("histogram");
-    expect(stats[statNames[0]]).toStrictEqual({});
+    expect(stats[statNames[0]]).toStrictEqual(defaultStatValues.histogram);
   });
 
   test("rasterStats - non-overlapping feature categorical return 0", async () => {

--- a/packages/geoprocessing/src/toolbox/geoblaze/rasterStats.test.e2e.ts
+++ b/packages/geoprocessing/src/toolbox/geoblaze/rasterStats.test.e2e.ts
@@ -1,10 +1,9 @@
 import { describe, test, expect } from "vitest";
-import { rasterStats } from "./rasterStats.js";
+import { rasterStats, defaultStatValues } from "./rasterStats.js";
 //@ts-ignore
 import geoblaze from "geoblaze";
 import testData from "./test/testData.js";
 import parseGeoraster from "georaster";
-import { defaultStatValues } from "./geoblaze.js";
 
 describe("rasterStats", () => {
   test("rasterStats - default sum", async () => {

--- a/packages/geoprocessing/src/toolbox/geoblaze/rasterStats.ts
+++ b/packages/geoprocessing/src/toolbox/geoblaze/rasterStats.ts
@@ -17,7 +17,7 @@ import {
 import { toRasterProjection, geoblazeDefaultStatValues } from "./geoblaze.js";
 import cloneDeep from "lodash/cloneDeep.js";
 
-// default values for stats
+// default values for all supported raster stats, beyond just geoblaze.stats
 export const defaultStatValues = {
   ...cloneDeep(geoblazeDefaultStatValues),
   area: 0,
@@ -83,15 +83,13 @@ export const rasterStats = async (
   let statsByBand: StatsObject[] = [];
   let finalStats: StatsObject[] = [];
 
-  // Build array of default stat values, that can be returned if raster can't be accessed or returns nothing
+  // Enhance default stat values with histogram categories if available
   let defaultStats: StatsObject[] = [];
   for (let i = 0; i < numBands; i++) {
     defaultStats[i] = {};
     // Initialize default values for published stats
     for (let j = 0; j < statsToPublish.length; j++) {
-      if (statsToPublish[j] === "area") {
-        defaultStats[i][statsToPublish[j]] = 0;
-      } else if (
+      if (
         statsToPublish[j] === "histogram" &&
         categorical &&
         categoryMetricValues

--- a/packages/geoprocessing/src/toolbox/geoblaze/rasterStats.ts
+++ b/packages/geoprocessing/src/toolbox/geoblaze/rasterStats.ts
@@ -9,8 +9,20 @@ import {
   MetricDimension,
 } from "../../types/index.js";
 import geoblaze, { Georaster } from "geoblaze";
-import { StatsObject, CalcStatsOptions } from "../../types/geoblaze.js";
-import { toRasterProjection, defaultStatValues } from "./geoblaze.js";
+import {
+  StatsObject,
+  CalcStatsOptions,
+  Histogram,
+} from "../../types/geoblaze.js";
+import { toRasterProjection, geoblazeDefaultStatValues } from "./geoblaze.js";
+import cloneDeep from "lodash/cloneDeep.js";
+
+// default values for stats
+export const defaultStatValues = {
+  ...cloneDeep(geoblazeDefaultStatValues),
+  area: 0,
+  histogram: {},
+};
 
 /**
  * options accepted by rasterStats
@@ -39,7 +51,6 @@ export interface RasterStatsOptions extends CalcStatsOptions {
  * Calculates over 10 different raster stats, optionally constrains to raster cells overlapping with feature.
  * Defaults to calculating only sum stat
  * If no cells found, returns 0 or null value for each stat as appropriate.
- * If categorical raster, only calculates "valid" stat
  */
 export const rasterStats = async (
   raster: Georaster,
@@ -61,7 +72,8 @@ export const rasterStats = async (
 
   // If area is included in stats list, then also include valid stat which is needed to calculate area later
   if (stats.includes("area")) statsToCalculate.push("valid");
-  // If categorical raster, only calculate valid stat
+
+  // if categorical, override stats to only include histogram
   if (categorical) {
     statsToCalculate = ["histogram"];
     statsToPublish = ["histogram"];
@@ -75,28 +87,37 @@ export const rasterStats = async (
   let defaultStats: StatsObject[] = [];
   for (let i = 0; i < numBands; i++) {
     defaultStats[i] = {};
-    for (let j = 0; j < stats.length; j++) {
-      if (stats[j] === "area") defaultStats[i][stats[j]] = 0;
-      else defaultStats[i][stats[j]] = defaultStatValues[stats[j]];
+    // Initialize default values for published stats
+    for (let j = 0; j < statsToPublish.length; j++) {
+      if (statsToPublish[j] === "area") {
+        defaultStats[i][statsToPublish[j]] = 0;
+      } else if (
+        statsToPublish[j] === "histogram" &&
+        categorical &&
+        categoryMetricValues
+      ) {
+        let hist = {};
+        categoryMetricValues.forEach((c) => (hist[c] = 0)); // load zero for each histogram category
+        defaultStats[i][statsToPublish[j]] = hist;
+      } else {
+        defaultStats[i][statsToPublish[j]] =
+          defaultStatValues[statsToPublish[j]];
+      }
     }
   }
 
   try {
-    // If categorical raster, use histogram to calculate valid cells
     if (categorical) {
-      const histogram = await geoblaze.histogram(raster, projectedFeat, {
+      const histogram = (await geoblaze.histogram(raster, projectedFeat, {
         scaleType: "nominal",
-      });
+      })) as Histogram[];
 
-      // If no overlap
-      if (!histogram.length) {
-        if (!categoryMetricValues || categoryMetricValues.length === 0) {
-          statsByBand = [{ histogram: {} }];
-        } else {
-          let hist = {};
-          categoryMetricValues.forEach((c) => (hist[c] = 0));
-          statsByBand = [{ histogram: hist }];
-        }
+      // If no overlap, return default values
+      if (
+        histogram.length === 0 ||
+        (histogram.length === 1 && Object.keys(histogram[0]).length === 0)
+      ) {
+        return defaultStats;
       } else {
         statsByBand = histogram.map((h) => {
           let hist = {};

--- a/packages/geoprocessing/src/toolbox/geoblaze/rasterStats.ts
+++ b/packages/geoprocessing/src/toolbox/geoblaze/rasterStats.ts
@@ -80,14 +80,13 @@ export const rasterStats = async (
   }
 
   const projectedFeat = toRasterProjection(raster, feature);
+  const finalStats: StatsObject[] = [];
   let statsByBand: StatsObject[] = [];
-  let finalStats: StatsObject[] = [];
 
-  // Enhance default stat values with histogram categories if available
-  let defaultStats: StatsObject[] = [];
+  // Package default values for only published stats. Enhance histogram default with categories if provided
+  const defaultStats: StatsObject[] = [];
   for (let i = 0; i < numBands; i++) {
     defaultStats[i] = {};
-    // Initialize default values for published stats
     for (let j = 0; j < statsToPublish.length; j++) {
       if (
         statsToPublish[j] === "histogram" &&

--- a/packages/geoprocessing/src/toolbox/overlapRasterClass.ts
+++ b/packages/geoprocessing/src/toolbox/overlapRasterClass.ts
@@ -9,7 +9,7 @@ import {
 } from "../types/index.js";
 import { isSketchCollection } from "../helpers/index.js";
 import { createMetric } from "../metrics/index.js";
-import { Histogram } from "../types/georaster.js";
+import { Histogram } from "../types/geoblaze.js";
 import { getHistogram } from "./geoblaze/index.js";
 import { featureEach } from "@turf/meta";
 

--- a/packages/geoprocessing/src/types/geoblaze.ts
+++ b/packages/geoprocessing/src/types/geoblaze.ts
@@ -64,7 +64,7 @@ export interface StatsObject {
   std?: Nullable<number>;
   /** Statistical measurement of spread between values in raster */
   variance?: Nullable<number>;
-  /** Histogram only for categorical raster */
+  /** Histogram object, for categorical raster, mapping category IDs to cell count */
   histogram?: Nullable<{}>;
 }
 
@@ -83,7 +83,7 @@ export interface CalcStatsOptions {
   filter?: (index: number, value: number) => boolean;
 }
 
-interface HistogramOptions {
+export interface HistogramOptions {
   scaleType: "nominal" | "ratio";
   /** required for ratio scaleType */
   numClasses?: number;
@@ -91,7 +91,7 @@ interface HistogramOptions {
   classType?: "equal-interval" | "quantile";
 }
 
-interface Histogram {
+export interface Histogram {
   [binKey: string]: number;
 }
 

--- a/packages/geoprocessing/src/types/georaster.ts
+++ b/packages/geoprocessing/src/types/georaster.ts
@@ -81,7 +81,3 @@ export type GeorasterMetadata = Pick<
   Georaster,
   "noDataValue" | "projection" | "xmin" | "ymax" | "pixelWidth" | "pixelHeight"
 >;
-
-export interface Histogram {
-  [classId: string]: number;
-}


### PR DESCRIPTION
Improves #315 

- fix no overlap check, was only checking for empty array when, at least 
- shift histogram default stat value calc
- shift histogram export