### PR TITLE
Support childProperties for SketchCollection

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30497,7 +30497,8 @@
         "vite": "^5.4.2",
         "vitest": "^2.0.5",
         "zx": "^8.1.5"
-      }
+      },
+      "devDependencies": {}
     },
     "packages/geoprocessing": {
       "name": "@seasketch/geoprocessing",
@@ -31254,7 +31255,8 @@
         "geojson-antimeridian-cut": "^0.1.0",
         "react-i18next": "^15.0.1",
         "union-subdivided-polygons": "^0.9.1"
-      }
+      },
+      "devDependencies": {}
     },
     "packages/template-ocean-eez": {
       "name": "@seasketch/template-ocean-eez",
@@ -31267,7 +31269,8 @@
         "geojson-antimeridian-cut": "^0.1.0",
         "react-i18next": "^15.0.1",
         "union-subdivided-polygons": "^0.9.1"
-      }
+      },
+      "devDependencies": {}
     }
   }
 }

--- a/packages/base-project/.storybook/genReportStories.ts
+++ b/packages/base-project/.storybook/genReportStories.ts
@@ -1,7 +1,12 @@
 import fs from "fs-extra";
 import path from "path";
 import { globby } from "globby";
-import { Sketch } from "@seasketch/geoprocessing/client-core";
+import {
+  isSketchCollection,
+  Sketch,
+  SketchCollection,
+  SketchProperties,
+} from "@seasketch/geoprocessing/client-core";
 import { GpStoryConfig } from "./types.js";
 import { v4 as uuid } from "uuid";
 
@@ -70,10 +75,10 @@ const sketchFilenames = fs
   );
 
 // console.log("sketchFilenames", sketchFilenames);
-const sketches: Sketch[] = [];
+const sketches: (Sketch | SketchCollection)[] = [];
 for (const sketchFilename of sketchFilenames) {
   try {
-    const sketch: Sketch = fs.readJSONSync(
+    const sketch: Sketch | SketchCollection = fs.readJSONSync(
       path.join(sketchDir, sketchFilename)
     ) as Sketch;
     if (sketch && sketch.properties.name) {
@@ -145,6 +150,18 @@ for (const storyConfig of storyConfigs) {
       continue;
     }
 
+    const childProperties: SketchProperties["childProperties"] = (() => {
+      if (isSketchCollection(sketch)) {
+        sketch.features.map((feature) => feature.properties);
+      }
+      return undefined;
+    })();
+
+    const newSketchProperties: SketchProperties = {
+      ...sketch.properties,
+      ...(childProperties ? { childProperties } : {}),
+    };
+
     const story = `
       import React from "react";
       import { ${storyConfig.componentName} } from '${importFromCacheStr}';
@@ -156,7 +173,7 @@ for (const storyConfig of storyConfigs) {
 
       const contextValue = sampleSketchReportContextValue({
         exampleOutputs: ${JSON.stringify(exampleOutputs, null, 2)},
-        sketchProperties: ${JSON.stringify(sketch.properties, null, 2)},
+        sketchProperties: ${JSON.stringify(newSketchProperties, null, 2)},
         projectUrl: "https://example.com/project",
         geometryUri: 'https://localhost/${uuid()}',
         visibleLayers: [],

--- a/packages/base-project/.storybook/genReportStories.ts
+++ b/packages/base-project/.storybook/genReportStories.ts
@@ -152,7 +152,7 @@ for (const storyConfig of storyConfigs) {
 
     const childProperties: SketchProperties["childProperties"] = (() => {
       if (isSketchCollection(sketch)) {
-        sketch.features.map((feature) => feature.properties);
+        return sketch.features.map((feature) => feature.properties);
       }
       return undefined;
     })();

--- a/packages/base-project/package.json
+++ b/packages/base-project/package.json
@@ -65,5 +65,6 @@
     "vite": "^5.4.2",
     "vitest": "^2.0.5",
     "zx": "^8.1.5"
-  }
+  },
+  "devDependencies": {}
 }

--- a/packages/geoprocessing/scripts/storybook/genReportStories.ts
+++ b/packages/geoprocessing/scripts/storybook/genReportStories.ts
@@ -1,7 +1,12 @@
 import fs from "fs-extra";
-import path, { extname } from "path";
+import path from "path";
 import { globby } from "globby";
-import { Sketch } from "../../src/types/sketch.js";
+import {
+  Sketch,
+  SketchCollection,
+  SketchProperties,
+} from "../../src/types/sketch.js";
+import { isSketchCollection } from "../../src/helpers/sketch.js";
 import { GpStoryConfig } from "../../src/storybook/types.js";
 import { v4 as uuid } from "uuid";
 
@@ -64,10 +69,10 @@ const sketchFilenames = fs
     (sketchFilename) =>
       path.basename(sketchFilename).startsWith("gp", 0) === false
   );
-const sketches: Sketch[] = [];
+const sketches: (Sketch | SketchCollection)[] = [];
 for (const sketchFilename of sketchFilenames) {
   try {
-    const sketch: Sketch = fs.readJSONSync(
+    const sketch: Sketch | SketchCollection = fs.readJSONSync(
       path.join(sketchDir, sketchFilename)
     ) as Sketch;
     if (sketch && sketch.properties.name) {
@@ -137,6 +142,18 @@ for (const storyConfig of storyConfigs) {
       continue;
     }
 
+    const childProperties: SketchProperties["childProperties"] = (() => {
+      if (isSketchCollection(sketch)) {
+        return sketch.features.map((feature) => feature.properties);
+      }
+      return undefined;
+    })();
+
+    const newSketchProperties: SketchProperties = {
+      ...sketch.properties,
+      ...(childProperties ? { childProperties } : {}),
+    };
+
     const story = `
       import React from "react";
       import { ${storyConfig.componentName} } from '${importFromCacheStr}';
@@ -148,7 +165,7 @@ for (const storyConfig of storyConfigs) {
 
       const contextValue = sampleSketchReportContextValue({
         exampleOutputs: ${JSON.stringify(exampleOutputs, null, 2)},
-        sketchProperties: ${JSON.stringify(sketch.properties, null, 2)},
+        sketchProperties: ${JSON.stringify(newSketchProperties, null, 2)},
         projectUrl: "https://example.com/project",
         geometryUri: 'https://localhost/${uuid()}',
         visibleLayers: [],

--- a/packages/geoprocessing/scripts/upgrade/updatePackage.test.ts
+++ b/packages/geoprocessing/scripts/upgrade/updatePackage.test.ts
@@ -103,27 +103,33 @@ describe("updatePackage", () => {
 
   test("devDependencies are updated", async () => {
     const updatedPkg = updatePackageJson(srcPkg, basePkg);
-    const keys = Object.keys(updatedPkg.devDependencies);
-    expect(keys.length).toEqual(4);
-    expect(keys.includes("vite")).toBeTruthy();
-    expect(keys.includes("vitest")).toBeTruthy();
-    expect(keys.includes("zx")).toBeTruthy();
-    expect(updatedPkg.devDependencies["vite"]).toEqual("^5.2.11");
-    expect(updatedPkg.devDependencies["vitest"]).toEqual("^1.6.0");
-    expect(updatedPkg.devDependencies["zx"]).toEqual("^8.1.0");
+    if (updatedPkg.devDependencies) {
+      const keys = Object.keys(updatedPkg.devDependencies);
+      expect(keys.length).toEqual(4);
+      expect(keys.includes("vite")).toBeTruthy();
+      expect(keys.includes("vitest")).toBeTruthy();
+      expect(keys.includes("zx")).toBeTruthy();
+      expect(updatedPkg.devDependencies["vite"]).toEqual("^5.2.11");
+      expect(updatedPkg.devDependencies["vitest"]).toEqual("^1.6.0");
+      expect(updatedPkg.devDependencies["zx"]).toEqual("^8.1.0");
+    }
   });
 
   test("otherPkgs are updated if present in srcPkg", async () => {
     const updatedPkg = updatePackageJson(srcPkg, basePkg, [otherPkg]);
     const scriptKeys = Object.keys(updatedPkg.scripts);
     const dependencyKeys = Object.keys(updatedPkg.dependencies);
-    const devDependencyKeys = Object.keys(updatedPkg.devDependencies);
-    expect(scriptKeys.length).toEqual(4);
-    expect(scriptKeys.includes("other-script")).toBeFalsy();
-    expect(dependencyKeys.length).toEqual(3);
-    expect(dependencyKeys.includes("other-dependency")).toBeFalsy();
-    expect(devDependencyKeys.length).toEqual(4);
-    expect(devDependencyKeys.includes("other-dev-dependency")).toBeTruthy();
-    expect(updatedPkg.devDependencies["other-dev-dependency"]).toEqual("1.0.0");
+    if (updatedPkg.devDependencies) {
+      const devDependencyKeys = Object.keys(updatedPkg.devDependencies);
+      expect(scriptKeys.length).toEqual(4);
+      expect(scriptKeys.includes("other-script")).toBeFalsy();
+      expect(dependencyKeys.length).toEqual(3);
+      expect(dependencyKeys.includes("other-dependency")).toBeFalsy();
+      expect(devDependencyKeys.length).toEqual(4);
+      expect(devDependencyKeys.includes("other-dev-dependency")).toBeTruthy();
+      expect(updatedPkg.devDependencies["other-dev-dependency"]).toEqual(
+        "1.0.0"
+      );
+    }
   });
 });

--- a/packages/geoprocessing/scripts/upgrade/updatePackage.ts
+++ b/packages/geoprocessing/scripts/upgrade/updatePackage.ts
@@ -37,11 +37,15 @@ export function updatePackageJson(
     }
   });
 
-  Object.keys(basePkg.devDependencies).forEach((key) => {
-    if (key !== "@seasketch/geoprocessing") {
-      projectPkg.devDependencies[key] = basePkg.devDependencies[key];
-    }
-  });
+  if (basePkg.devDependencies && projectPkg.devDependencies) {
+    Object.keys(basePkg.devDependencies).forEach((key) => {
+      if (basePkg.devDependencies && projectPkg.devDependencies) {
+        if (key !== "@seasketch/geoprocessing") {
+          projectPkg.devDependencies[key] = basePkg.devDependencies[key];
+        }
+      }
+    });
+  }
 
   // add otherPkgs to projectPkg if present, skip scripts
   otherPkgs.forEach((otherPkg) => {
@@ -54,19 +58,24 @@ export function updatePackageJson(
       }
     });
 
-    Object.keys(otherPkg.devDependencies).forEach((key) => {
-      if (
-        key !== "@seasketch/geoprocessing" &&
-        hasOwnProperty(projectPkg.devDependencies, key)
-      ) {
-        projectPkg.devDependencies[key] = otherPkg.devDependencies[key];
-      }
-    });
+    if (otherPkg.devDependencies) {
+      Object.keys(otherPkg.devDependencies).forEach((key) => {
+        if (projectPkg.devDependencies && otherPkg.devDependencies) {
+          if (
+            key !== "@seasketch/geoprocessing" &&
+            hasOwnProperty(projectPkg.devDependencies, key)
+          ) {
+            projectPkg.devDependencies[key] = otherPkg.devDependencies[key];
+          }
+        }
+      });
+    }
   });
 
   projectPkg.scripts = sortObjectKeys(projectPkg.scripts);
   projectPkg.dependencies = sortObjectKeys(projectPkg.dependencies);
-  projectPkg.devDependencies = sortObjectKeys(projectPkg.devDependencies);
+  if (projectPkg.devDependencies)
+    projectPkg.devDependencies = sortObjectKeys(projectPkg.devDependencies);
 
   return projectPkg;
 }

--- a/packages/geoprocessing/src/types/package.ts
+++ b/packages/geoprocessing/src/types/package.ts
@@ -34,7 +34,7 @@ export const loadedPackageSchema = z.object({
   bugs: z.record(z.string()).optional(),
   repository: z.record(z.string()).optional(),
   dependencies: z.record(z.string()),
-  devDependencies: z.record(z.string()),
+  devDependencies: z.record(z.string()).optional(),
   scripts: z.record(z.string()),
   private: z.boolean(),
   type: z.string().optional(),

--- a/packages/geoprocessing/src/types/sketch.ts
+++ b/packages/geoprocessing/src/types/sketch.ts
@@ -21,6 +21,7 @@ export type SketchProperties = Record<string, any> & {
   sketchClassId: string;
   isCollection: boolean;
   userAttributes: UserAttribute[];
+  childProperties?: SketchProperties[];
 };
 
 /** User-defined attributes with values for Sketch.  Defines known keys as well as unknown for extensiblity */

--- a/packages/template-blank-project/package.json
+++ b/packages/template-blank-project/package.json
@@ -27,5 +27,6 @@
     "geojson-antimeridian-cut": "^0.1.0",
     "react-i18next": "^15.0.1",
     "union-subdivided-polygons": "^0.9.1"
-  }
+  },
+  "devDependencies": {}
 }

--- a/packages/template-ocean-eez/package.json
+++ b/packages/template-ocean-eez/package.json
@@ -27,5 +27,6 @@
     "geojson-antimeridian-cut": "^0.1.0",
     "react-i18next": "^15.0.1",
     "union-subdivided-polygons": "^0.9.1"
-  }
+  },
+  "devDependencies": {}
 }


### PR DESCRIPTION
When a user chooses to view reports for a SketchCollection, the SeaSketch platform passes the SketchProperties of the parent.  It also now incudes an optional `childProperties` property to give access to the child properties.  Report clients can migrate to using this, and away from returning a NullSketchCollection in function results.

- childProperties is now available as an optional property on SketchProperties.
- genReportStories now creates childProperties on thy from the example sketch it receives as input, when it is a SketchCollection.