### PR TITLE
Disable task cache for worker lambdas by default, improve logging

### DIFF
--- a/packages/geoprocessing/src/aws/GeoprocessingHandler.ts
+++ b/packages/geoprocessing/src/aws/GeoprocessingHandler.ts
@@ -132,6 +132,9 @@ export class GeoprocessingHandler<
     const { Tasks, options } = this;
     const serviceName = options.title;
 
+    console.log("event", JSON.stringify(event, null, 2));
+    console.log("context", JSON.stringify(context, null, 2));
+
     const request = this.parseRequest<G>(event);
 
     const handlerTime = Date.now();
@@ -258,7 +261,8 @@ export class GeoprocessingHandler<
     let task: GeoprocessingTask = await Tasks.create(
       serviceName,
       request.cacheKey,
-      wss
+      wss,
+      request.disableServerCache
     );
 
     if (

--- a/packages/geoprocessing/src/aws/GeoprocessingHandler.ts
+++ b/packages/geoprocessing/src/aws/GeoprocessingHandler.ts
@@ -132,8 +132,8 @@ export class GeoprocessingHandler<
     const { Tasks, options } = this;
     const serviceName = options.title;
 
-    console.log("event", JSON.stringify(event, null, 2));
-    console.log("context", JSON.stringify(context, null, 2));
+    // console.log("event", JSON.stringify(event, null, 2));
+    // console.log("context", JSON.stringify(context, null, 2));
 
     const request = this.parseRequest<G>(event);
 
@@ -258,12 +258,11 @@ export class GeoprocessingHandler<
       wss = request.wss;
     }
 
-    let task: GeoprocessingTask = await Tasks.create(
-      serviceName,
-      request.cacheKey,
+    let task: GeoprocessingTask = await Tasks.create(serviceName, {
+      id: request.cacheKey,
       wss,
-      request.disableServerCache
-    );
+      disableServerCache: request.disableServerCache,
+    });
 
     if (
       this.options.executionMode === "sync" ||

--- a/packages/geoprocessing/src/aws/GeoprocessingHandler.ts
+++ b/packages/geoprocessing/src/aws/GeoprocessingHandler.ts
@@ -332,9 +332,9 @@ export class GeoprocessingHandler<
 
           return promise;
         } catch (e: unknown) {
-          let failureMessage = `Exception running geoprocessing function ${this.options.title}, ${request.cacheKey}`;
+          let failureMessage = `Error while running geoprocessing function ${this.options.title}`;
           if (e instanceof Error) {
-            failureMessage += `:\n ${e.message} \n ${e.stack}`;
+            failureMessage += `: ${e.message}`;
           }
           console.log(failureMessage);
           if (e instanceof Error) {

--- a/packages/geoprocessing/src/aws/GeoprocessingHandler.ts
+++ b/packages/geoprocessing/src/aws/GeoprocessingHandler.ts
@@ -261,7 +261,7 @@ export class GeoprocessingHandler<
     let task: GeoprocessingTask = await Tasks.create(serviceName, {
       id: request.cacheKey,
       wss,
-      disableServerCache: request.disableServerCache,
+      disableCache: request.disableCache,
     });
 
     if (

--- a/packages/geoprocessing/src/aws/helpers.ts
+++ b/packages/geoprocessing/src/aws/helpers.ts
@@ -35,7 +35,11 @@ export async function runLambdaWorker(
   functionName: string,
   region: string,
   functionParameters = {},
-  request: GeoprocessingRequestModel<Polygon | MultiPolygon>
+  request: GeoprocessingRequestModel<Polygon | MultiPolygon>,
+  options: {
+    /** Whether server should cache result of worker task */
+    serverShouldCache?: boolean;
+  }
 ): Promise<InvocationResponse> {
   // Create cache key for this task
   const cacheKey = genTaskCacheKey(functionName, sketch.properties, {
@@ -77,6 +81,7 @@ export async function runLambdaWorker(
     geometryUri: `${location}/geometry`,
     status: GeoprocessingTaskStatus.Pending,
     estimate: 2,
+    disableServerCache: options.serverShouldCache || false, // default to false
   };
 
   const client = new LambdaClient({});

--- a/packages/geoprocessing/src/aws/helpers.ts
+++ b/packages/geoprocessing/src/aws/helpers.ts
@@ -72,26 +72,10 @@ export async function runLambdaWorker(
   })();
   const payload = JSON.stringify(workerRequest, null, 2);
 
-  // Configure task
-  const location = `/${region}/tasks/${cacheKey}`;
-  const task: GeoprocessingTask = {
-    id: cacheKey,
-    service: region,
-    wss: "",
-    location,
-    startedAt: new Date().toISOString(),
-    logUriTemplate: `${location}/logs{?limit,nextToken}`,
-    geometryUri: `${location}/geometry`,
-    status: GeoprocessingTaskStatus.Pending,
-    estimate: 2,
-    disableServerCache,
-  };
-
   const client = new LambdaClient({});
   return client.send(
     new InvokeCommand({
       FunctionName: `gp-${projectName}-sync-${functionName}`,
-      ClientContext: Buffer.from(JSON.stringify(task)).toString("base64"),
       InvocationType: "RequestResponse",
       Payload: payload,
     })

--- a/packages/geoprocessing/src/aws/helpers.ts
+++ b/packages/geoprocessing/src/aws/helpers.ts
@@ -54,6 +54,7 @@ export async function runLambdaWorker(
       geometryUri: request.geometryUri,
       extraParams: functionParameters,
       cacheKey,
+      disableServerCache,
     };
 
     // Encode sketch to geobuf if larger than max request size

--- a/packages/geoprocessing/src/aws/helpers.ts
+++ b/packages/geoprocessing/src/aws/helpers.ts
@@ -123,6 +123,10 @@ export function parseLambdaResponse(
 
     return JSON.parse(payload.body).data;
   } catch {
-    throw Error(`Failed to parse response from AWS lambda: ${lambdaResult}`);
+    console.log(
+      "Failed to parse response from lambdaResult",
+      JSON.stringify(lambdaResult, null, 2)
+    );
+    throw Error(`Failed to parse response from AWS lambda`);
   }
 }

--- a/packages/geoprocessing/src/aws/helpers.ts
+++ b/packages/geoprocessing/src/aws/helpers.ts
@@ -37,10 +37,12 @@ export async function runLambdaWorker(
   functionParameters = {},
   request: GeoprocessingRequestModel<Polygon | MultiPolygon>,
   options: {
-    /** Whether server should cache result of worker task */
-    serverShouldCache?: boolean;
-  }
+    /** Whether cache of worker task should be disabled, defaults to false */
+    disableServerCache?: boolean;
+  } = {}
 ): Promise<InvocationResponse> {
+  const { disableServerCache = false } = options;
+
   // Create cache key for this task
   const cacheKey = genTaskCacheKey(functionName, sketch.properties, {
     cacheId: `${JSON.stringify(functionParameters)}`,
@@ -81,7 +83,7 @@ export async function runLambdaWorker(
     geometryUri: `${location}/geometry`,
     status: GeoprocessingTaskStatus.Pending,
     estimate: 2,
-    disableServerCache: options.serverShouldCache || false, // default to false
+    disableServerCache,
   };
 
   const client = new LambdaClient({});

--- a/packages/geoprocessing/src/aws/helpers.ts
+++ b/packages/geoprocessing/src/aws/helpers.ts
@@ -54,7 +54,7 @@ export async function runLambdaWorker(
       geometryUri: request.geometryUri,
       extraParams: functionParameters,
       cacheKey,
-      disableServerCache: !enableCache,
+      disableCache: !enableCache,
     };
 
     // Encode sketch to geobuf if larger than max request size

--- a/packages/geoprocessing/src/aws/helpers.ts
+++ b/packages/geoprocessing/src/aws/helpers.ts
@@ -41,7 +41,7 @@ export async function runLambdaWorker(
     disableServerCache?: boolean;
   } = {}
 ): Promise<InvocationResponse> {
-  const { disableServerCache = false } = options;
+  const { disableServerCache = true } = options;
 
   // Create cache key for this task
   const cacheKey = genTaskCacheKey(functionName, sketch.properties, {

--- a/packages/geoprocessing/src/aws/helpers.ts
+++ b/packages/geoprocessing/src/aws/helpers.ts
@@ -37,11 +37,11 @@ export async function runLambdaWorker(
   functionParameters = {},
   request: GeoprocessingRequestModel<Polygon | MultiPolygon>,
   options: {
-    /** Whether cache of worker task should be disabled, defaults to false */
-    disableServerCache?: boolean;
+    /** Whether cache of worker task should be enabled, defaults to false */
+    enableCache?: boolean;
   } = {}
 ): Promise<InvocationResponse> {
-  const { disableServerCache = true } = options;
+  const { enableCache = false } = options;
 
   // Create cache key for this task
   const cacheKey = genTaskCacheKey(functionName, sketch.properties, {
@@ -54,7 +54,7 @@ export async function runLambdaWorker(
       geometryUri: request.geometryUri,
       extraParams: functionParameters,
       cacheKey,
-      disableServerCache,
+      disableServerCache: !enableCache,
     };
 
     // Encode sketch to geobuf if larger than max request size

--- a/packages/geoprocessing/src/aws/tasks.test.e2e.ts
+++ b/packages/geoprocessing/src/aws/tasks.test.e2e.ts
@@ -85,7 +85,7 @@ describe("DynamoDB local", () => {
   }, 10000);
 
   test("create new task with cache disabled should have no record", async () => {
-    const task = await Tasks.create(SERVICE_NAME, { disableServerCache: true });
+    const task = await Tasks.create(SERVICE_NAME, { disableCache: true });
     expect(typeof task.id).toBe("string");
     expect(task.status).toBe("pending");
     // make sure it saves to the db
@@ -200,7 +200,7 @@ describe("DynamoDB local", () => {
   });
 
   test("completed task with disabled cached should return no result", async () => {
-    const task = await Tasks.create(SERVICE_NAME, { disableServerCache: true });
+    const task = await Tasks.create(SERVICE_NAME, { disableCache: true });
     const metrics = [createMetric({ value: 15, sketchId: "test" })];
     const response = await Tasks.complete(task, {
       metrics,

--- a/packages/geoprocessing/src/aws/tasks.test.e2e.ts
+++ b/packages/geoprocessing/src/aws/tasks.test.e2e.ts
@@ -85,7 +85,7 @@ describe("DynamoDB local", () => {
   }, 10000);
 
   test("create new task with cache disabled should have no record", async () => {
-    const task = await Tasks.create(SERVICE_NAME, undefined, undefined, true);
+    const task = await Tasks.create(SERVICE_NAME, { disableServerCache: true });
     expect(typeof task.id).toBe("string");
     expect(task.status).toBe("pending");
     // make sure it saves to the db
@@ -101,7 +101,7 @@ describe("DynamoDB local", () => {
   }, 10000);
 
   test("create new async task", async () => {
-    const task = await Tasks.create(SERVICE_NAME, undefined, "wssabc123");
+    const task = await Tasks.create(SERVICE_NAME, { wss: "wssabc123" });
     expect(typeof task.id).toBe("string");
     expect(task.status).toBe("pending");
     // make sure it saves to the db
@@ -129,7 +129,7 @@ describe("DynamoDB local", () => {
   });
 
   test("create task with a cacheKey id", async () => {
-    const task = await Tasks.create(SERVICE_NAME, "my-cache-key");
+    const task = await Tasks.create(SERVICE_NAME, { id: "my-cache-key" });
     expect(typeof task.id).toBe("string");
     expect(task.status).toBe("pending");
     // make sure it saves to the db
@@ -200,7 +200,7 @@ describe("DynamoDB local", () => {
   });
 
   test("completed task with disabled cached should return no result", async () => {
-    const task = await Tasks.create(SERVICE_NAME, undefined, undefined, true);
+    const task = await Tasks.create(SERVICE_NAME, { disableServerCache: true });
     const metrics = [createMetric({ value: 15, sketchId: "test" })];
     const response = await Tasks.complete(task, {
       metrics,

--- a/packages/geoprocessing/src/aws/tasks.test.e2e.ts
+++ b/packages/geoprocessing/src/aws/tasks.test.e2e.ts
@@ -84,6 +84,22 @@ describe("DynamoDB local", () => {
     expect(item && item.Item && item.Item.id).toBe(task.id);
   }, 10000);
 
+  test("create new task with cache disabled should have no record", async () => {
+    const task = await Tasks.create(SERVICE_NAME, undefined, undefined, true);
+    expect(typeof task.id).toBe("string");
+    expect(task.status).toBe("pending");
+    // make sure it saves to the db
+    const item = await docClient.get({
+      TableName: "tasks-core",
+      Key: {
+        id: task.id,
+        service: SERVICE_NAME,
+      },
+    });
+    console.log(JSON.stringify(item, null, 2));
+    expect(item.Item).toBeUndefined();
+  }, 10000);
+
   test("create new async task", async () => {
     const task = await Tasks.create(SERVICE_NAME, undefined, "wssabc123");
     expect(typeof task.id).toBe("string");
@@ -181,6 +197,19 @@ describe("DynamoDB local", () => {
     expect(cachedMetrics).toBeTruthy();
     expect(isMetricArray(cachedMetrics)).toBe(true);
     expect(deepEqual(cachedMetrics, metrics)).toBe(true);
+  });
+
+  test("completed task with disabled cached should return no result", async () => {
+    const task = await Tasks.create(SERVICE_NAME, undefined, undefined, true);
+    const metrics = [createMetric({ value: 15, sketchId: "test" })];
+    const response = await Tasks.complete(task, {
+      metrics,
+    });
+    expect(response.statusCode).toBe(200);
+
+    const cachedResult = await Tasks.get(SERVICE_NAME, task.id);
+
+    expect(cachedResult).toBeUndefined();
   });
 
   test("tasks for multiple services should not get mixed", async () => {

--- a/packages/geoprocessing/src/aws/tasks.ts
+++ b/packages/geoprocessing/src/aws/tasks.ts
@@ -36,7 +36,7 @@ export interface GeoprocessingTask<ResultType = any> {
   data?: ResultType; // result data can take any json-serializable form
   error?: string;
   estimate: number;
-  disableServerCache?: boolean; // whether to cache the result server-side, defaults to true
+  disableCache?: boolean; // whether to cache the result server-side, defaults to true
   // ttl?: number;
 }
 
@@ -107,11 +107,11 @@ export default class TasksModel {
       id?: string;
       /** websocket url */
       wss?: string;
-      disableServerCache?: boolean;
+      disableCache?: boolean;
     } = {}
   ) {
     const task = this.init(service, options.id, options.wss);
-    task.disableServerCache = options.disableServerCache;
+    task.disableCache = options.disableCache;
 
     try {
       let estimate = await this.getMeanEstimate(task);
@@ -121,8 +121,7 @@ export default class TasksModel {
     }
 
     const shouldCache =
-      task.disableServerCache === undefined ||
-      task.disableServerCache === false;
+      task.disableCache === undefined || task.disableCache === false;
 
     if (shouldCache) {
       await this.db.send(
@@ -153,8 +152,7 @@ export default class TasksModel {
     task.duration = new Date().getTime() - new Date(task.startedAt).getTime();
 
     const shouldCache =
-      task.disableServerCache === undefined ||
-      task.disableServerCache === false;
+      task.disableCache === undefined || task.disableCache === false;
 
     console.log("shouldCache", shouldCache);
 
@@ -333,8 +331,7 @@ export default class TasksModel {
     task.error = errorDescription;
 
     const shouldCache =
-      task.disableServerCache === undefined ||
-      task.disableServerCache === false;
+      task.disableCache === undefined || task.disableCache === false;
 
     if (shouldCache) {
       await this.db.send(

--- a/packages/geoprocessing/src/aws/tasks.ts
+++ b/packages/geoprocessing/src/aws/tasks.ts
@@ -31,7 +31,8 @@ export interface GeoprocessingTask<ResultType = any> {
   logUriTemplate: string;
   geometryUri: string;
   status: GeoprocessingTaskStatus;
-  wss: string; // websocket for listening to status updates
+  /** websocket url */
+  wss: string;
   data?: ResultType; // result data can take any json-serializable form
   error?: string;
   estimate: number;
@@ -75,6 +76,7 @@ export default class TasksModel {
   init(
     service: string,
     id?: string,
+    /** websocket url */
     wss?: string,
     startedAt?: string,
     duration?: number,
@@ -100,13 +102,16 @@ export default class TasksModel {
 
   async create(
     service: string,
-    /** Cache key */
-    id?: string,
-    wss?: string,
-    disableServerCache?: boolean
+    options: {
+      /** Unique identifier for this task, used as cache key.  If not provided a uuid is created */
+      id?: string;
+      /** websocket url */
+      wss?: string;
+      disableServerCache?: boolean;
+    } = {}
   ) {
-    const task = this.init(service, id, wss);
-    task.disableServerCache = disableServerCache;
+    const task = this.init(service, options.id, options.wss);
+    task.disableServerCache = options.disableServerCache;
 
     try {
       let estimate = await this.getMeanEstimate(task);

--- a/packages/geoprocessing/src/aws/tasks.ts
+++ b/packages/geoprocessing/src/aws/tasks.ts
@@ -116,9 +116,9 @@ export default class TasksModel {
     }
 
     const shouldCache =
-      task.disableServerCache === undefined || task.disableServerCache === false
-        ? true
-        : false;
+      task.disableServerCache === undefined ||
+      task.disableServerCache === false;
+
     if (shouldCache) {
       await this.db.send(
         new PutCommand({
@@ -148,9 +148,9 @@ export default class TasksModel {
     task.duration = new Date().getTime() - new Date(task.startedAt).getTime();
 
     const shouldCache =
-      task.disableServerCache === undefined || task.disableServerCache === false
-        ? true
-        : false;
+      task.disableServerCache === undefined ||
+      task.disableServerCache === false;
+
     console.log("shouldCache", shouldCache);
 
     if (shouldCache) {
@@ -328,9 +328,8 @@ export default class TasksModel {
     task.error = errorDescription;
 
     const shouldCache =
-      task.disableServerCache === undefined || task.disableServerCache === false
-        ? true
-        : false;
+      task.disableServerCache === undefined ||
+      task.disableServerCache === false;
 
     if (shouldCache) {
       await this.db.send(

--- a/packages/geoprocessing/src/types/service.ts
+++ b/packages/geoprocessing/src/types/service.ts
@@ -131,7 +131,7 @@ export interface GeoprocessingRequestModel<G = SketchGeometryTypes> {
   checkCacheOnly?: string;
   onSocketConnect?: string;
   /** If true, task state and result is not cached server-side.  Only use for sync functions in a worker use case where its results are not needed */
-  disableServerCache?: boolean;
+  disableCache?: boolean;
 }
 
 /**

--- a/packages/geoprocessing/src/types/service.ts
+++ b/packages/geoprocessing/src/types/service.ts
@@ -124,10 +124,14 @@ export interface GeoprocessingRequestModel<G = SketchGeometryTypes> {
   /** Additional runtime parameters */
   extraParams?: GeoprocessingRequestParams;
   token?: string;
+  /** Cache key for this task */
   cacheKey?: string;
   wss?: string;
+  /** If true, only check cache and do not run worker */
   checkCacheOnly?: string;
   onSocketConnect?: string;
+  /** If true, task state and result is not cached server-side.  Only use for sync functions in a worker use case where its results are not needed */
+  disableServerCache?: boolean;
 }
 
 /**


### PR DESCRIPTION
Workers caching their task results increases the number of dynamodb items per report run by significantly.  If 1 gp function splits its work over 5 workers, then there's 5 times as many dynamodb items.  The current assumption is that the parent gp function will cache their results, and therefore the worker results don't need to be cached.  This will cut down on the amount of dynamodb writes.

Requirements
- Give runLambdaWorker caller control over whether caching or not.  Defaults to not cache.  Can be turned on for debugging purposes.

ToDo:
- [x] Add disableServerCache option to geoprocessing handler request and task model
- [x] Switch to default to not cache
- [x] refactor task.create to use options object