### PR TITLE
Separate worker stacks and lock functions to one stack

### DIFF
--- a/packages/geoprocessing/scripts/aws/GeoprocessingStack.ts
+++ b/packages/geoprocessing/scripts/aws/GeoprocessingStack.ts
@@ -47,6 +47,8 @@ export interface GeoprocessingStackProps extends StackProps {
   projectPath: string;
   manifest: Manifest;
   functionsPerStack?: number;
+  functionGroups?: string[][];
+  workerGroups?: string[][];
 }
 
 /**

--- a/packages/geoprocessing/scripts/aws/GeoprocessingStack.ts
+++ b/packages/geoprocessing/scripts/aws/GeoprocessingStack.ts
@@ -43,12 +43,18 @@ import { hasOwnProperty } from "../../client-core.js";
 
 /** StackProps extended with geoprocessing project metadata */
 export interface GeoprocessingStackProps extends StackProps {
+  /** Name of the geoprocessing project */
   projectName: string;
+  /** Path to top-level of geoprocessing project */
   projectPath: string;
+  /** Manifest used to figure out what resources should be created for this stack */
   manifest: Manifest;
+  /** maximum number of functions to allow per LambdaStack */
   functionsPerStack?: number;
-  functionGroups?: string[][];
-  workerGroups?: string[][];
+  /** State of function stacks if already deployed (by function title) */
+  existingFunctionStacks?: string[][];
+  /** State of worker stacks if already deployed (by function title) */
+  existingWorkerStacks?: string[][];
 }
 
 /**

--- a/packages/geoprocessing/scripts/aws/LambdaStack.ts
+++ b/packages/geoprocessing/scripts/aws/LambdaStack.ts
@@ -26,6 +26,7 @@ export interface GeoprocessingNestedStackProps extends NestedStackProps {
   projectPath: string;
   manifest: Manifest;
   functionsPerStack?: number;
+  functionGroups?: ProcessingFunctionMetadata[][];
 }
 
 /**

--- a/packages/geoprocessing/scripts/aws/LambdaStack.ts
+++ b/packages/geoprocessing/scripts/aws/LambdaStack.ts
@@ -26,7 +26,8 @@ export interface GeoprocessingNestedStackProps extends NestedStackProps {
   projectPath: string;
   manifest: Manifest;
   functionsPerStack?: number;
-  functionGroups?: ProcessingFunctionMetadata[][];
+  functionGroups?: string[][];
+  workerGroups?: string[][];
 }
 
 /**

--- a/packages/geoprocessing/scripts/aws/LambdaStack.ts
+++ b/packages/geoprocessing/scripts/aws/LambdaStack.ts
@@ -64,7 +64,6 @@ export class LambdaStack extends NestedStack {
 
     // Create lambdas for all functions
     this.createProcessingFunctions();
-    this.createLambdaSyncPolicies();
   }
 
   getProcessingFunctions() {
@@ -216,10 +215,8 @@ export class LambdaStack extends NestedStack {
   /**
    * Given run lambda functions across all lambda stacks, creates policies allowing them to invoke sync lambdas within this lambda stack
    */
-  createLambdaSyncPolicies() {
-    const runLambdas: Function[] = this.getAsyncRunLambdas();
-
-    // Create invoke policy for each sync function in this lambda stack
+  createLambdaSyncPolicies(runLambdas: Function[]) {
+    // Create invoke policy for each worker function in this lambda stack
     const invokeSyncLambdaPolicies = this.syncLambdaArns.map((arn) => {
       return new PolicyStatement({
         effect: Effect.ALLOW,

--- a/packages/geoprocessing/scripts/aws/LambdaStack.ts
+++ b/packages/geoprocessing/scripts/aws/LambdaStack.ts
@@ -22,12 +22,18 @@ import {
 import config from "./config.js";
 import path from "path";
 export interface GeoprocessingNestedStackProps extends NestedStackProps {
+  /** Name of the geoprocessing project */
   projectName: string;
+  /** Path to top-level of geoprocessing project */
   projectPath: string;
+  /** Manifest used to figure out what resources should be created for this stack */
   manifest: Manifest;
+  /** maximum number of functions to allow per LambdaStack */
   functionsPerStack?: number;
-  functionGroups?: string[][];
-  workerGroups?: string[][];
+  /** State of function stacks if already deployed (by function title) */
+  existingFunctionStacks?: string[][];
+  /** State of worker stacks if already deployed (by function title) */
+  existingWorkerStacks?: string[][];
 }
 
 /**

--- a/packages/geoprocessing/scripts/aws/LambdaStack.ts
+++ b/packages/geoprocessing/scripts/aws/LambdaStack.ts
@@ -30,7 +30,7 @@ export interface GeoprocessingNestedStackProps extends NestedStackProps {
   manifest: Manifest;
   /** maximum number of functions to allow per LambdaStack */
   functionsPerStack?: number;
-  /** State of function stacks if already deployed (by function title) */
+  /** State of function stacks if already deployed (by function title). */
   existingFunctionStacks?: string[][];
   /** State of worker stacks if already deployed (by function title) */
   existingWorkerStacks?: string[][];

--- a/packages/geoprocessing/scripts/aws/StackAll.test.e2e.ts
+++ b/packages/geoprocessing/scripts/aws/StackAll.test.e2e.ts
@@ -193,6 +193,198 @@ describe("GeoprocessingStack - all components", () => {
     });
   }, 200000);
 
+  test("GeoprocessingStack - all components with existing", async () => {
+    await setupBuildDirs(projectPath);
+
+    const manifest = await createTestBuild(projectName, projectPath, [
+      "preprocessor",
+      "syncGeoprocessor",
+      "asyncGeoprocessorWithWorker",
+      "asyncGeoprocessorWorker",
+      "client",
+    ]);
+
+    expect(manifest.clients.length).toBe(1);
+    expect(manifest.preprocessingFunctions.length).toBe(1);
+    expect(manifest.geoprocessingFunctions.length).toBe(3);
+
+    const app = new App();
+
+    // pass existing resources in different order than it typically would create, and include stale resources not present in manifest
+    const stack = new GeoprocessingStack(app, projectName, {
+      env: { region: manifest.region },
+      projectName,
+      manifest,
+      projectPath,
+      functionsPerStack: 2,
+      existingFunctionStacks: [
+        ["noLongerAsyncGeoprocessor"],
+        ["testSyncGeoprocessor"],
+        ["testAsyncGeoprocessor"],
+      ],
+      existingWorkerStacks: [["noLongerWorker", "testWorker"]],
+    });
+
+    // Expected stack order based on existing is [[syncGeoprocessor], ['asyncGeoprocessor'], ['testPreprocessor'], ['testWorker']]
+
+    const rootTemplate = Template.fromStack(stack);
+
+    // Lambda stack assertions
+
+    const lambdaStacks = stack.node.children.filter(
+      (child) => child instanceof NestedStack,
+    );
+    expect(lambdaStacks.length).toBe(4);
+
+    // Lambda stack CDK template assertions
+
+    const lambdaStackTemplate0 = Template.fromStack(
+      lambdaStacks[0] as NestedStack,
+    );
+
+    const lambdaStackTemplate1 = Template.fromStack(
+      lambdaStacks[1] as NestedStack,
+    );
+
+    const lambdaStackTemplate2 = Template.fromStack(
+      lambdaStacks[2] as NestedStack,
+    );
+
+    // worker stack
+    const lambdaStackTemplate3 = Template.fromStack(
+      lambdaStacks[3] as NestedStack,
+    );
+
+    // Generate JSON snapshot.  Use to manually assess what cdk synth produces and write tests
+    // Does not currently enforce matching with toMatchSnapshot() because dynamic values like S3Key are not consistent
+
+    const snapPath = "./scripts/aws/__snapshots__/";
+    fs.ensureDirSync(snapPath);
+    fs.writeJSONSync(
+      `${snapPath}/StackAll_rootStack.test.e2e.ts.snap`,
+      rootTemplate.toJSON(),
+      {
+        spaces: 2,
+      },
+    );
+    fs.writeJSONSync(
+      `${snapPath}/StackAll_lambdaStack.test.e2e.ts.snap`,
+      lambdaStackTemplate0.toJSON(),
+      {
+        spaces: 2,
+      },
+    );
+
+    // Root stack assertions
+
+    expect(stack.hasClients()).toEqual(true);
+    expect(stack.hasSyncFunctions()).toEqual(true);
+    expect(stack.hasAsyncFunctions()).toEqual(true);
+    expect(stack.getSyncFunctionMetas().length).toBe(3);
+    expect(stack.getAsyncFunctionMetas().length).toBe(1);
+    expect(stack.getSyncFunctionsWithMeta().length).toBe(3);
+    expect(stack.getAsyncFunctionsWithMeta().length).toBe(1);
+
+    rootTemplate.resourceCountIs("AWS::CloudFront::Distribution", 1);
+    rootTemplate.resourceCountIs("AWS::S3::Bucket", 3);
+    rootTemplate.resourceCountIs("AWS::ApiGateway::RestApi", 1);
+    rootTemplate.resourceCountIs("AWS::ApiGateway::Stage", 1);
+    rootTemplate.resourceCountIs("AWS::ApiGateway::Method", 13); // root (get, options), async (get, post, options), preprocessor (options, post), sync (get, post, options), sync worker (get, post, options)
+    rootTemplate.resourceCountIs("AWS::ApiGatewayV2::Api", 1); // web socket api
+    rootTemplate.resourceCountIs("AWS::ApiGatewayV2::Stage", 1);
+    rootTemplate.resourceCountIs("AWS::ApiGatewayV2::Route", 3);
+    rootTemplate.resourceCountIs("AWS::DynamoDB::Table", 3);
+    rootTemplate.resourceCountIs("AWS::Lambda::Function", 6);
+
+    rootTemplate.allResourcesProperties("AWS::ApiGateway::Stage", {
+      StageName: config.STAGE_NAME,
+    });
+
+    // Check shared resources
+    rootTemplate.hasResourceProperties("AWS::ApiGateway::RestApi", {
+      Name: `gp-${projectName}`,
+    });
+    rootTemplate.hasResourceProperties("AWS::S3::Bucket", {
+      BucketName: `gp-${projectName}-results`,
+    });
+    rootTemplate.hasResourceProperties("AWS::S3::Bucket", {
+      BucketName: `gp-${projectName}-datasets`,
+    });
+    rootTemplate.hasResourceProperties("AWS::Lambda::Function", {
+      Handler: "serviceHandlers.projectMetadata",
+      Runtime: config.NODE_RUNTIME.name,
+    });
+    rootTemplate.hasResourceProperties("AWS::DynamoDB::Table", {
+      TableName: `gp-${projectName}-tasks`,
+    });
+    rootTemplate.hasResourceProperties("AWS::DynamoDB::Table", {
+      TableName: `gp-${projectName}-estimates`,
+    });
+
+    // // Check shared async resources
+    rootTemplate.hasResourceProperties("AWS::ApiGatewayV2::Api", {
+      ProtocolType: "WEBSOCKET",
+      Name: `gp-${projectName}-socket`,
+    });
+    rootTemplate.hasResourceProperties("AWS::DynamoDB::Table", {
+      TableName: `gp-${projectName}-subscriptions`,
+    });
+    rootTemplate.hasResourceProperties("AWS::Lambda::Function", {
+      FunctionName: `gp-${projectName}-subscribe`,
+      Handler: "connect.connectHandler",
+      Runtime: config.NODE_RUNTIME.name,
+    });
+    rootTemplate.hasResourceProperties("AWS::Lambda::Function", {
+      FunctionName: `gp-${projectName}-unsubscribe`,
+      Handler: "disconnect.disconnectHandler",
+      Runtime: config.NODE_RUNTIME.name,
+    });
+    rootTemplate.hasResourceProperties("AWS::Lambda::Function", {
+      FunctionName: `gp-${projectName}-send`,
+      Handler: "sendmessage.sendHandler",
+      Runtime: config.NODE_RUNTIME.name,
+    });
+
+    // // Check client resources
+    rootTemplate.hasResourceProperties("AWS::S3::Bucket", {
+      BucketName: `gp-${projectName}-client`,
+    });
+
+    // Check sync geoprocessing function resources in lambda stack 0
+    lambdaStackTemplate0.hasResourceProperties("AWS::Lambda::Function", {
+      FunctionName: `gp-${projectName}-sync-${manifest.geoprocessingFunctions[0].title}`,
+      Handler: getHandlerPointer(manifest.geoprocessingFunctions[0]),
+      Runtime: config.NODE_RUNTIME.name,
+    });
+
+    // Check async function resources in lambda stack 1
+    lambdaStackTemplate1.hasResourceProperties("AWS::Lambda::Function", {
+      FunctionName: `gp-${projectName}-async-${manifest.geoprocessingFunctions[1].title}-start`,
+      Handler: getHandlerPointer(manifest.geoprocessingFunctions[1]),
+      Runtime: config.NODE_RUNTIME.name,
+    });
+
+    lambdaStackTemplate1.hasResourceProperties("AWS::Lambda::Function", {
+      FunctionName: `gp-${projectName}-async-${manifest.geoprocessingFunctions[1].title}-run`,
+      Handler: getHandlerPointer(manifest.geoprocessingFunctions[1]),
+      Runtime: config.NODE_RUNTIME.name,
+    });
+
+    // Check preprocessor resources in lambda stack index 2
+    lambdaStackTemplate2.hasResourceProperties("AWS::Lambda::Function", {
+      FunctionName: `gp-${projectName}-sync-${manifest.preprocessingFunctions[0].title}`,
+      Handler: getHandlerPointer(manifest.preprocessingFunctions[0]),
+      Runtime: config.NODE_RUNTIME.name,
+    });
+
+    // and worker function
+    lambdaStackTemplate3.hasResourceProperties("AWS::Lambda::Function", {
+      FunctionName: `gp-${projectName}-sync-${manifest.geoprocessingFunctions[2].title}`,
+      Handler: getHandlerPointer(manifest.geoprocessingFunctions[2]),
+      Runtime: config.NODE_RUNTIME.name,
+    });
+  }, 200000);
+
   test("GeoprocessingStack - double worker use should throw", async () => {
     await setupBuildDirs(projectPath);
 

--- a/packages/geoprocessing/scripts/aws/StackAll.test.e2e.ts
+++ b/packages/geoprocessing/scripts/aws/StackAll.test.e2e.ts
@@ -46,7 +46,7 @@ describe("GeoprocessingStack - all components", () => {
     const lambdaStacks = stack.node.children.filter(
       (child) => child instanceof NestedStack,
     );
-    expect(lambdaStacks.length).toBe(2);
+    expect(lambdaStacks.length).toBe(3);
 
     // Lambda stack CDK template assertions
 
@@ -56,6 +56,11 @@ describe("GeoprocessingStack - all components", () => {
 
     const lambdaStackTemplate1 = Template.fromStack(
       lambdaStacks[1] as NestedStack,
+    );
+
+    // worker stack
+    const lambdaStackTemplate2 = Template.fromStack(
+      lambdaStacks[2] as NestedStack,
     );
 
     // Generate JSON snapshot.  Use to manually assess what cdk synth produces and write tests
@@ -166,10 +171,10 @@ describe("GeoprocessingStack - all components", () => {
       Runtime: config.NODE_RUNTIME.name,
     });
 
-    // and sync worker function
+    // and preprocessor resources
     lambdaStackTemplate0.hasResourceProperties("AWS::Lambda::Function", {
-      FunctionName: `gp-${projectName}-sync-${manifest.geoprocessingFunctions[2].title}`,
-      Handler: getHandlerPointer(manifest.geoprocessingFunctions[2]),
+      FunctionName: `gp-${projectName}-sync-${manifest.preprocessingFunctions[0].title}`,
+      Handler: getHandlerPointer(manifest.preprocessingFunctions[0]),
       Runtime: config.NODE_RUNTIME.name,
     });
 
@@ -180,10 +185,10 @@ describe("GeoprocessingStack - all components", () => {
       Runtime: config.NODE_RUNTIME.name,
     });
 
-    // and preprocessor resources
-    lambdaStackTemplate1.hasResourceProperties("AWS::Lambda::Function", {
-      FunctionName: `gp-${projectName}-sync-${manifest.preprocessingFunctions[0].title}`,
-      Handler: getHandlerPointer(manifest.preprocessingFunctions[0]),
+    // and worker function
+    lambdaStackTemplate2.hasResourceProperties("AWS::Lambda::Function", {
+      FunctionName: `gp-${projectName}-sync-${manifest.geoprocessingFunctions[2].title}`,
+      Handler: getHandlerPointer(manifest.geoprocessingFunctions[2]),
       Runtime: config.NODE_RUNTIME.name,
     });
   }, 200000);

--- a/packages/geoprocessing/scripts/aws/StackAll.test.e2e.ts
+++ b/packages/geoprocessing/scripts/aws/StackAll.test.e2e.ts
@@ -21,7 +21,7 @@ describe("GeoprocessingStack - all components", () => {
     const manifest = await createTestBuild(projectName, projectPath, [
       "preprocessor",
       "syncGeoprocessor",
-      "asyncGeoprocessor",
+      "asyncGeoprocessorWithWorker",
       "asyncGeoprocessorWorker",
       "client",
     ]);

--- a/packages/geoprocessing/scripts/aws/lambdaResources.ts
+++ b/packages/geoprocessing/scripts/aws/lambdaResources.ts
@@ -31,9 +31,6 @@ export const createLambdaStacks = (
   const asyncTitles = Object.keys(asyncFunctionMap);
   const syncTitles = Object.keys(syncFunctionMap);
 
-  console.log("functionGroupsAlready", props.existingFunctionStacks);
-  console.log("workerGroupsAlready", props.existingWorkerStacks);
-
   // Map of async function titles to their worker function titles
   const asyncWorkerMap: Record<string, string[]> = {};
   for (const func of props.manifest.geoprocessingFunctions) {

--- a/packages/geoprocessing/scripts/aws/lambdaResources.ts
+++ b/packages/geoprocessing/scripts/aws/lambdaResources.ts
@@ -31,6 +31,9 @@ export const createLambdaStacks = (
   const asyncTitles = Object.keys(asyncFunctionMap);
   const syncTitles = Object.keys(syncFunctionMap);
 
+  console.log("functionGroupsAlready", props.functionGroups);
+  console.log("workerGroupsAlready", props.workerGroups);
+
   // Map of async function titles to their worker function titles
   const asyncWorkerMap: Record<string, string[]> = {};
   for (const func of props.manifest.geoprocessingFunctions) {
@@ -133,11 +136,11 @@ export const createLambdaStacks = (
   });
 
   new CfnOutput(stack, "functionGroups", {
-    value: JSON.stringify(functionGroups),
+    value: JSON.stringify(functionGroups.map((g) => g.map((f) => f.title))),
   });
 
   new CfnOutput(stack, "workerGroups", {
-    value: JSON.stringify(workerGroups),
+    value: JSON.stringify(workerGroups.map((g) => g.map((f) => f.title))),
   });
 
   const functionStacks = functionGroups.map((funcGroup, i) => {

--- a/packages/geoprocessing/scripts/aws/lambdaResources.ts
+++ b/packages/geoprocessing/scripts/aws/lambdaResources.ts
@@ -10,6 +10,7 @@ import {
 import { keyBy } from "../../client-core.js";
 import { CfnOutput } from "aws-cdk-lib";
 import { chunk } from "../../src/index.js";
+import { Function } from "aws-cdk-lib/aws-lambda";
 
 /**
  * Creates lambda sub-stacks, as many as needed so as not to break resource limit
@@ -173,6 +174,17 @@ export const createLambdaStacks = (
     });
 
     return newStack;
+  });
+
+  // get all run lambdas and create policies for them to invoke workers
+  const runLambdas: Function[] = functionStacks.reduce<Function[]>(
+    (acc, curStack) => {
+      return [...acc, ...curStack.getAsyncRunLambdas()];
+    },
+    [],
+  );
+  workerStacks.forEach((stack) => {
+    stack.createLambdaSyncPolicies(runLambdas);
   });
 
   return [...functionStacks, ...workerStacks];

--- a/packages/geoprocessing/scripts/deploy/deployStack.ts
+++ b/packages/geoprocessing/scripts/deploy/deployStack.ts
@@ -3,6 +3,7 @@ import path from "path";
 import { App, Tags } from "aws-cdk-lib";
 import { Manifest } from "../manifest.js";
 import { GeoprocessingStack } from "../aws/GeoprocessingStack.js";
+import { CloudFormation } from "@aws-sdk/client-cloudformation";
 
 if (!process.env.PROJECT_PATH) {
   throw new Error("PROJECT_PATH env var not specified");
@@ -10,13 +11,39 @@ if (!process.env.PROJECT_PATH) {
 
 const PROJECT_PATH = process.env.PROJECT_PATH;
 
+const pkg = JSON.parse(
+  fs.readFileSync(path.join(PROJECT_PATH, "package.json")).toString(),
+);
+const packageName = pkg.name;
+
 const manifest: Manifest = JSON.parse(
   fs
     .readFileSync(path.join(PROJECT_PATH, ".build", "manifest.json"))
     .toString(),
 );
 
+const geoprocessing = JSON.parse(
+  fs
+    .readFileSync(path.join(PROJECT_PATH, "project", "geoprocessing.json"))
+    .toString(),
+);
+
+const cf = new CloudFormation({
+  region: geoprocessing.region,
+});
+
 export async function deployStack() {
+  const describeOutputs = await cf.describeStacks({
+    StackName: `gp-${packageName}`,
+  });
+
+  if (describeOutputs.Stacks && describeOutputs.Stacks[0].Outputs) {
+    const Outputs = describeOutputs.Stacks[0].Outputs;
+    const lambdaStackList = Outputs.find(
+      (o) => o.OutputKey === "lambdaStackList",
+    )?.OutputValue;
+  }
+
   const app = new App();
   const stack = new GeoprocessingStack(app, `gp-${manifest.title}`, {
     env: { region: manifest.region },
@@ -28,4 +55,5 @@ export async function deployStack() {
   Tags.of(stack).add("Cost Center", "seasketch-geoprocessing");
   Tags.of(stack).add("Geoprocessing Project", manifest.title);
 }
+
 deployStack();

--- a/packages/geoprocessing/scripts/deploy/deployStack.ts
+++ b/packages/geoprocessing/scripts/deploy/deployStack.ts
@@ -1,7 +1,7 @@
 import fs from "fs";
 import path from "path";
 import { App, Tags } from "aws-cdk-lib";
-import { Manifest } from "../manifest.js";
+import { Manifest, ProcessingFunctionMetadata } from "../manifest.js";
 import { GeoprocessingStack } from "../aws/GeoprocessingStack.js";
 import { CloudFormation } from "@aws-sdk/client-cloudformation";
 
@@ -33,16 +33,34 @@ const cf = new CloudFormation({
 });
 
 export async function deployStack() {
-  // const describeOutputs = await cf.describeStacks({
-  //   StackName: `gp-${packageName}`,
-  // });
+  let functionGroups: string[][] = [];
+  let workerGroups: string[][] = [];
 
-  // if (describeOutputs.Stacks && describeOutputs.Stacks[0].Outputs) {
-  //   const Outputs = describeOutputs.Stacks[0].Outputs;
-  //   const lambdaStackList = Outputs.find(
-  //     (o) => o.OutputKey === "lambdaStackList",
-  //   )?.OutputValue;
-  // }
+  try {
+    const describeOutputs = await cf.describeStacks({
+      StackName: `gp-${packageName}`,
+    });
+
+    if (describeOutputs.Stacks && describeOutputs.Stacks[0].Outputs) {
+      const Outputs = describeOutputs.Stacks[0].Outputs;
+
+      const functionGroupsJson = Outputs.find(
+        (o) => o.OutputKey === "functionGroups",
+      )?.OutputValue;
+      const workerGroupsJson = Outputs.find(
+        (o) => o.OutputKey === "workeerGroups",
+      )?.OutputValue;
+
+      if (functionGroupsJson && functionGroupsJson.length > 0) {
+        functionGroups = JSON.parse(functionGroupsJson);
+      }
+      if (workerGroupsJson && workerGroupsJson.length > 0) {
+        workerGroups = JSON.parse(workerGroupsJson);
+      }
+    }
+  } catch (err) {
+    // stack doesn't exist, keep going
+  }
 
   const app = new App();
   const stack = new GeoprocessingStack(app, `gp-${manifest.title}`, {
@@ -50,6 +68,8 @@ export async function deployStack() {
     projectName: manifest.title,
     manifest,
     projectPath: PROJECT_PATH,
+    functionGroups,
+    workerGroups,
   });
   Tags.of(stack).add("Author", manifest.author);
   Tags.of(stack).add("Cost Center", "seasketch-geoprocessing");

--- a/packages/geoprocessing/scripts/deploy/deployStack.ts
+++ b/packages/geoprocessing/scripts/deploy/deployStack.ts
@@ -33,16 +33,16 @@ const cf = new CloudFormation({
 });
 
 export async function deployStack() {
-  const describeOutputs = await cf.describeStacks({
-    StackName: `gp-${packageName}`,
-  });
+  // const describeOutputs = await cf.describeStacks({
+  //   StackName: `gp-${packageName}`,
+  // });
 
-  if (describeOutputs.Stacks && describeOutputs.Stacks[0].Outputs) {
-    const Outputs = describeOutputs.Stacks[0].Outputs;
-    const lambdaStackList = Outputs.find(
-      (o) => o.OutputKey === "lambdaStackList",
-    )?.OutputValue;
-  }
+  // if (describeOutputs.Stacks && describeOutputs.Stacks[0].Outputs) {
+  //   const Outputs = describeOutputs.Stacks[0].Outputs;
+  //   const lambdaStackList = Outputs.find(
+  //     (o) => o.OutputKey === "lambdaStackList",
+  //   )?.OutputValue;
+  // }
 
   const app = new App();
   const stack = new GeoprocessingStack(app, `gp-${manifest.title}`, {

--- a/packages/geoprocessing/scripts/testing/createTestBuild.ts
+++ b/packages/geoprocessing/scripts/testing/createTestBuild.ts
@@ -127,6 +127,38 @@ export default async function createTestBuild(
       requiresProperties: [],
       executionMode: "async",
       memory: 4096,
+    });
+    `,
+    );
+  }
+
+  if (components.includes("asyncGeoprocessorWithWorker")) {
+    gpConfig = {
+      ...gpConfig,
+      geoprocessingFunctions: [
+        ...gpConfig.geoprocessingFunctions,
+        "src/functions/testAsyncGeoprocessor.ts",
+      ],
+    };
+
+    fs.writeFileSync(
+      `${projectPath}/src/functions/testAsyncGeoprocessor.ts`,
+      `
+    import { Feature, Point } from "geojson";
+    import { point } from "@turf/turf";
+    import { GeoprocessingHandler } from "../../../../../src/aws/GeoprocessingHandler.js";
+
+    const testAsyncGeoprocessor = async (feature: Feature<Point>) => {
+      return point([0, 0]);
+    };
+
+    export default new GeoprocessingHandler(testAsyncGeoprocessor, {
+      title: "testAsyncGeoprocessor",
+      description: "Test async geoprocessor",
+      timeout: 40,
+      requiresProperties: [],
+      executionMode: "async",
+      memory: 4096,
       workers: ['testWorker'],
     });
     `,

--- a/packages/geoprocessing/scripts/testing/types.ts
+++ b/packages/geoprocessing/scripts/testing/types.ts
@@ -2,6 +2,7 @@ export type TestComponentTypes =
   | "preprocessor"
   | "syncGeoprocessor"
   | "asyncGeoprocessor"
+  | "asyncGeoprocessorWithWorker"
   | "asyncGeoprocessorTwoSameWorker"
   | "asyncGeoprocessorMissingWork"
   | "asyncGeoprocessorWorker"


### PR DESCRIPTION
This PR solves two issues:
- it solves the circular dependency issue in a better way.  Instead of keeping worker lambdas in the same stack as their parent, it puts all workder lambdas instead into separate LambdaStacks, so you have two sets of stacks.  This better supports more advanced use cases like two gp functions both using the same worker.  When new functions get added to a project, they will fill out existing stacks before creating new ones.
- it locks gp functions to the first stack they get deployed to.  This prevents deploy errors when functions move from one stack to another and CloudFormation isn't smart enough to delete the other Lambda first and claims a duplicate resource (because fixed lambdas ID).  stack assignments are maintained between deploys in CfnOutput.