### PR TITLE
init: fix setting package version, gpVersion override

### DIFF
--- a/packages/base-project/package.json
+++ b/packages/base-project/package.json
@@ -49,6 +49,9 @@
   "dependencies": {
     "@babel/cli": "^7.25.6",
     "@babel/plugin-syntax-import-attributes": "^7.25.6",
+    "@babel/preset-env": "^7.25.4",
+    "@babel/preset-react": "^7.24.7",
+    "@babel/preset-typescript": "^7.24.7",
     "@seasketch/geoprocessing": "^7.0.0-beta.8",
     "@storybook/addon-essentials": "^8.2.9",
     "@storybook/addon-interactions": "^8.2.9",

--- a/packages/geoprocessing/scripts/init/bin.ts
+++ b/packages/geoprocessing/scripts/init/bin.ts
@@ -17,5 +17,4 @@ program
     }
   });
 
-console.log("process.argv", JSON.stringify(process.argv, null, 2));
 program.parse(process.argv);

--- a/packages/geoprocessing/scripts/init/bin.ts
+++ b/packages/geoprocessing/scripts/init/bin.ts
@@ -17,4 +17,5 @@ program
     }
   });
 
+console.log("process.argv", JSON.stringify(process.argv, null, 2));
 program.parse(process.argv);

--- a/packages/geoprocessing/scripts/init/createProject.ts
+++ b/packages/geoprocessing/scripts/init/createProject.ts
@@ -155,6 +155,11 @@ export async function createProject(
     JSON.stringify(packageJSON, null, 2),
   );
 
+  const savedPackage: Package = JSON.parse(
+    fs.readFileSync(`${getGeoprocessingPath()}/package.json`).toString(),
+  );
+  console.log("savedPackage", savedPackage);
+
   spinner.succeed("updated package.json");
 
   spinner.start("creating geoprocessing.json");

--- a/packages/geoprocessing/scripts/init/createProject.ts
+++ b/packages/geoprocessing/scripts/init/createProject.ts
@@ -156,9 +156,9 @@ export async function createProject(
   );
 
   const savedPackage: Package = JSON.parse(
-    fs.readFileSync(`${baseProjectPath}/package.json`).toString(),
+    fs.readFileSync(`${projectPath}/package.json`).toString(),
   );
-  console.log("savedPackage", savedPackage);
+  console.log("savedPackageAfterWrite", savedPackage);
 
   spinner.succeed("updated package.json");
 

--- a/packages/geoprocessing/scripts/init/createProject.ts
+++ b/packages/geoprocessing/scripts/init/createProject.ts
@@ -357,22 +357,27 @@ export async function createProject(
   // Install dependencies including adding GP.
   if (interactive) {
     spinner.start("installing dependencies with npm");
-    try {
-      await exec(`npm install`, {
-        cwd: metadata.name,
-      });
-      spinner.succeed("installed dependencies");
-      spinner.start("extracting translations");
-      await exec(`npm run extract:translation`, {
-        cwd: metadata.name,
-      });
-    } catch (error: unknown) {
-      if (error instanceof Error) {
-        console.log(error.message);
-        console.log(error.stack);
-        process.exit();
-      }
-    }
+    const savedPackage: Package = JSON.parse(
+      fs.readFileSync(`${projectPath}/package.json`).toString(),
+    );
+    console.log("savedPackageBeforeInstall", savedPackage);
+
+    // try {
+    //   await exec(`npm install`, {
+    //     cwd: metadata.name,
+    //   });
+    //   spinner.succeed("installed dependencies");
+    //   spinner.start("extracting translations");
+    //   await exec(`npm run extract:translation`, {
+    //     cwd: metadata.name,
+    //   });
+    // } catch (error: unknown) {
+    //   if (error instanceof Error) {
+    //     console.log(error.message);
+    //     console.log(error.stack);
+    //     process.exit();
+    //   }
+    // }
 
     spinner.succeed("extracted initial translations");
   }

--- a/packages/geoprocessing/scripts/init/createProject.ts
+++ b/packages/geoprocessing/scripts/init/createProject.ts
@@ -135,21 +135,15 @@ export async function createProject(
     private: false,
   };
 
+  console.log("gpVersion", gpVersion);
+  console.log("packageJSON", packageJSON);
+
   if (gpVersion) {
-    if (packageJSON.devDependencies) {
-      packageJSON.devDependencies["@seasketch/geoprocessing"] = gpVersion;
-    } else {
-      packageJSON.devDependencies = { "@seasketch/geoprocessing": gpVersion };
-    }
+    spinner.start(`Installing user-defined GP version ${gpVersion}`);
+    packageJSON.dependencies!["@seasketch/geoprocessing"] = gpVersion;
     spinner.succeed(`Installing user-defined GP version ${gpVersion}`);
   } else {
-    if (packageJSON.devDependencies) {
-      packageJSON.devDependencies["@seasketch/geoprocessing"] = curGpVersion;
-    } else {
-      packageJSON.devDependencies = {
-        "@seasketch/geoprocessing": curGpVersion,
-      };
-    }
+    packageJSON.dependencies!["@seasketch/geoprocessing"] = curGpVersion;
   }
 
   await fs.writeFile(

--- a/packages/geoprocessing/scripts/init/createProject.ts
+++ b/packages/geoprocessing/scripts/init/createProject.ts
@@ -137,6 +137,7 @@ export async function createProject(
 
   console.log("gpVersion", gpVersion);
   console.log("packageJSON", packageJSON);
+  console.log("curGpVersion", curGpVersion);
 
   if (gpVersion) {
     spinner.start(`Installing user-defined GP version ${gpVersion}`);

--- a/packages/geoprocessing/scripts/init/createProject.ts
+++ b/packages/geoprocessing/scripts/init/createProject.ts
@@ -114,6 +114,7 @@ export async function createProject(
       fs.readFileSync(`${baseProjectPath}/package.json`).toString(),
     ),
     name,
+    version: "0.1.0",
     description,
     author,
     license,

--- a/packages/geoprocessing/scripts/init/createProject.ts
+++ b/packages/geoprocessing/scripts/init/createProject.ts
@@ -135,8 +135,9 @@ export async function createProject(
     private: false,
   };
 
+  console.log();
   console.log("gpVersion", gpVersion);
-  console.log("packageJSON", packageJSON);
+  console.log("packageJSON before", packageJSON);
   console.log("curGpVersion", curGpVersion);
 
   if (gpVersion) {
@@ -147,9 +148,11 @@ export async function createProject(
     packageJSON.dependencies!["@seasketch/geoprocessing"] = curGpVersion;
   }
 
+  console.log("packageJSON after", packageJSON);
+
   await fs.writeFile(
     `${projectPath}/package.json`,
-    JSON.stringify(packageJSON, null, "  "),
+    JSON.stringify(packageJSON, null, 2),
   );
 
   spinner.succeed("updated package.json");

--- a/packages/geoprocessing/scripts/init/createProject.ts
+++ b/packages/geoprocessing/scripts/init/createProject.ts
@@ -135,11 +135,6 @@ export async function createProject(
     private: false,
   };
 
-  console.log();
-  console.log("gpVersion", gpVersion);
-  console.log("packageJSON before", packageJSON);
-  console.log("curGpVersion", curGpVersion);
-
   if (gpVersion) {
     spinner.start(`Installing user-defined GP version ${gpVersion}`);
     packageJSON.dependencies!["@seasketch/geoprocessing"] = gpVersion;
@@ -148,17 +143,10 @@ export async function createProject(
     packageJSON.dependencies!["@seasketch/geoprocessing"] = curGpVersion;
   }
 
-  console.log("packageJSON after", packageJSON);
-
   await fs.writeFile(
     `${projectPath}/package.json`,
     JSON.stringify(packageJSON, null, 2),
   );
-
-  const savedPackage: Package = JSON.parse(
-    fs.readFileSync(`${projectPath}/package.json`).toString(),
-  );
-  console.log("savedPackageAfterWrite", savedPackage);
 
   spinner.succeed("updated package.json");
 
@@ -357,27 +345,23 @@ export async function createProject(
   // Install dependencies including adding GP.
   if (interactive) {
     spinner.start("installing dependencies with npm");
-    const savedPackage: Package = JSON.parse(
-      fs.readFileSync(`${projectPath}/package.json`).toString(),
-    );
-    console.log("savedPackageBeforeInstall", savedPackage);
 
-    // try {
-    //   await exec(`npm install`, {
-    //     cwd: metadata.name,
-    //   });
-    //   spinner.succeed("installed dependencies");
-    //   spinner.start("extracting translations");
-    //   await exec(`npm run extract:translation`, {
-    //     cwd: metadata.name,
-    //   });
-    // } catch (error: unknown) {
-    //   if (error instanceof Error) {
-    //     console.log(error.message);
-    //     console.log(error.stack);
-    //     process.exit();
-    //   }
-    // }
+    try {
+      await exec(`npm install`, {
+        cwd: metadata.name,
+      });
+      spinner.succeed("installed dependencies");
+      spinner.start("extracting translations");
+      await exec(`npm run extract:translation`, {
+        cwd: metadata.name,
+      });
+    } catch (error: unknown) {
+      if (error instanceof Error) {
+        console.log(error.message);
+        console.log(error.stack);
+        process.exit();
+      }
+    }
 
     spinner.succeed("extracted initial translations");
   }

--- a/packages/geoprocessing/scripts/init/createProject.ts
+++ b/packages/geoprocessing/scripts/init/createProject.ts
@@ -156,7 +156,7 @@ export async function createProject(
   );
 
   const savedPackage: Package = JSON.parse(
-    fs.readFileSync(`${getGeoprocessingPath()}/package.json`).toString(),
+    fs.readFileSync(`${baseProjectPath}/package.json`).toString(),
   );
   console.log("savedPackage", savedPackage);
 

--- a/packages/geoprocessing/scripts/init/init.ts
+++ b/packages/geoprocessing/scripts/init/init.ts
@@ -236,7 +236,7 @@ async function init(gpVersion?: string) {
 
 if (import.meta.url === pathToFileURL(process.argv[1]).href) {
   // module was not imported but called directly
-  await init();
+  await init(process.argv[2]);
 }
 
 export { init };

--- a/packages/geoprocessing/scripts/init/init.ts
+++ b/packages/geoprocessing/scripts/init/init.ts
@@ -18,7 +18,6 @@ const licenseDefaults = ["MIT", "UNLICENSED", "BSD-3-Clause", "APACHE-2.0"];
 const allLicenseOptions = [...licenses, "UNLICENSED"];
 
 async function init(gpVersion?: string) {
-  console.log("gpVersion top init", gpVersion);
   const defaultName = userMeta.name;
   const defaultEmail = userMeta.email;
 

--- a/packages/geoprocessing/scripts/init/init.ts
+++ b/packages/geoprocessing/scripts/init/init.ts
@@ -18,6 +18,7 @@ const licenseDefaults = ["MIT", "UNLICENSED", "BSD-3-Clause", "APACHE-2.0"];
 const allLicenseOptions = [...licenses, "UNLICENSED"];
 
 async function init(gpVersion?: string) {
+  console.log("gpVersion top init", gpVersion);
   const defaultName = userMeta.name;
   const defaultEmail = userMeta.email;
 

--- a/packages/geoprocessing/scripts/template/addTemplate.ts
+++ b/packages/geoprocessing/scripts/template/addTemplate.ts
@@ -177,8 +177,8 @@ export async function copyTemplates(
       fs.readFileSync(`${templatePath}/package.json`).toString(),
     );
     // Remove the templates seasketch dependency, the version will not match if running from canary gp release, and don't want it to overwrite
-    if (templatePackage.devDependencies)
-      delete templatePackage.devDependencies["@seasketch/geoprocessing"];
+    if (templatePackage.dependencies)
+      delete templatePackage.dependencies["@seasketch/geoprocessing"];
     const projectPackage: Package = JSON.parse(
       fs.readFileSync(`${projectPath}/package.json`).toString(),
     );

--- a/packages/geoprocessing/scripts/template/addTemplate.ts
+++ b/packages/geoprocessing/scripts/template/addTemplate.ts
@@ -177,8 +177,8 @@ export async function copyTemplates(
       fs.readFileSync(`${templatePath}/package.json`).toString(),
     );
     // Remove the templates seasketch dependency, the version will not match if running from canary gp release, and don't want it to overwrite
-    if (templatePackage.dependencies)
-      delete templatePackage.dependencies["@seasketch/geoprocessing"];
+    if (templatePackage.devDependencies)
+      delete templatePackage.devDependencies["@seasketch/geoprocessing"];
     const projectPackage: Package = JSON.parse(
       fs.readFileSync(`${projectPath}/package.json`).toString(),
     );


### PR DESCRIPTION
- `version` in package.json now getting set to 0.1 instead of picking up whatever the gp version was in base-project/package.json.
- when using gpVersion override for installing experimental canary, it would install geoprocessing package to devDependencies still, switched to dependencies since everything is installed there now.
- It's now possible to execute dist/scripts/init/init.js directly and pass gpVersion e.g. - `node geoprocessing/dist/scripts/init/init.js @seasketch/geoprocessing@7.0.0-experimental-init-fixez.9`