### PR TITLE
speed up storybook, merge existing project prettierignore with base on upgrade

### DIFF
--- a/packages/base-project/.storybook/main.ts
+++ b/packages/base-project/.storybook/main.ts
@@ -10,7 +10,6 @@ const config: StorybookConfig = {
   addons: [
     "@storybook/addon-links",
     "@storybook/addon-essentials",
-
     "@storybook/addon-interactions",
   ],
   framework: {

--- a/packages/base-project/.storybook/main.ts
+++ b/packages/base-project/.storybook/main.ts
@@ -26,8 +26,8 @@ const config: StorybookConfig = {
     },
     disableTelemetry: true,
   },
-  docs: {
-    autodocs: "tag",
+  typescript: {
+    reactDocgen: false,
   },
 };
 export default config;

--- a/packages/geoprocessing/scripts/aws/lambdaResources.ts
+++ b/packages/geoprocessing/scripts/aws/lambdaResources.ts
@@ -123,11 +123,13 @@ export const createLambdaStacks = (
     FUNCTIONS_PER_STACK,
   );
 
-  for (const [index, group] of functionGroups.entries()) {
-    console.log(
-      `Lambda stack ${index}:\n ${group.map((f) => f.title).join("\n ")}`,
-    );
-    console.log("");
+  if (process.env.NODE_ENV !== "test") {
+    for (const [index, group] of functionGroups.entries()) {
+      console.log(
+        `Lambda stack ${index}:\n ${group.map((f) => f.title).join("\n ")}`,
+      );
+      console.log("");
+    }
   }
 
   new CfnOutput(stack, "stacksFunction", {

--- a/packages/geoprocessing/scripts/upgrade/upgrade.ts
+++ b/packages/geoprocessing/scripts/upgrade/upgrade.ts
@@ -194,10 +194,16 @@ if (fs.existsSync(`${PROJECT_PATH}/.prettierignore`)) {
     }
   }
 
-  // Convert back to string of lines
-  const ignoreLines = gpIgnoreArray.reduce<string>((acc, line) => {
-    return line.length > 0 ? acc.concat(line + "\n") : "";
-  }, "\n");
+  // Convert back to string, with strings separates by newlines
+  const ignoreLines = gpIgnoreArray.reduce<string>((acc, line, curIndex) => {
+    if (line.length === 0) {
+      return "";
+    }
+    if (curIndex === gpIgnoreArray.length - 1) {
+      return acc.concat(line);
+    }
+    return acc.concat(line + "\n");
+  }, "");
 
   await fs.writeFile(`${PROJECT_PATH}/.prettierignore`, ignoreLines);
 } else {

--- a/packages/geoprocessing/scripts/upgrade/upgrade.ts
+++ b/packages/geoprocessing/scripts/upgrade/upgrade.ts
@@ -170,8 +170,39 @@ const pc = await fs.readFile("project/projectClient.ts", "utf8");
 const newPc = pc.replace("../geoprocessing.json", "./geoprocessing.json");
 fs.writeFile("project/projectClient.ts", newPc, "utf8");
 
-// copy prettier config files
-await $`cp -r ${GP_PATH}/dist/base-project/.prettier* .`;
+// copy prettier config file
+await $`cp -r ${GP_PATH}/dist/base-project/.prettierrc.json .`;
+
+// Merge prettier ignore file if exists
+if (fs.existsSync(`${PROJECT_PATH}/.prettierignore`)) {
+  // Convert to array of lines
+  const projIgnoreArray = fs
+    .readFileSync(`${PROJECT_PATH}/.prettierignore`)
+    .toString()
+    .split("\n");
+
+  const gpIgnoreArray = fs
+    .readFileSync(`${GP_PATH}/dist/base-project/.prettierignore`)
+    .toString()
+    .split("\n");
+
+  for (const line of projIgnoreArray) {
+    if (gpIgnoreArray.includes(line)) {
+      continue;
+    } else {
+      gpIgnoreArray.push(line);
+    }
+  }
+
+  // Convert back to string of lines
+  const ignoreLines = gpIgnoreArray.reduce<string>((acc, line) => {
+    return line.length > 0 ? acc.concat(line + "\n") : "";
+  }, "\n");
+
+  await fs.writeFile(`${PROJECT_PATH}/.prettierignore`, ignoreLines);
+} else {
+  await $`cp -r ${GP_PATH}/dist/base-project/.prettierignore .`;
+}
 
 //// rekey package.json ////
 


### PR DESCRIPTION
Merging instead of overwriting .prettierignore file allows project to add custom lines and they won't be lost when you run the `upgrade` command.