### PR TITLE
Fix precalc cleanup script

### DIFF
--- a/packages/geoprocessing/scripts/base/datasources/precalcCleanup.test.e2e.ts
+++ b/packages/geoprocessing/scripts/base/datasources/precalcCleanup.test.e2e.ts
@@ -64,4 +64,34 @@ describe("precalcCleanup", () => {
       expect(m.geographyId).toBe("eez");
     });
   });
+
+  test("precalcCleanup - drop malformed metrics", () => {
+    const projectClient = new ProjectClientBase({
+      ...configFixtures.loaded,
+      precalc: configFixtures.loaded.precalc.concat([
+        {
+          geographyId: "eez",
+          metricId: "area",
+          classId: "global-eez-mr-v12", // Needs "-class"
+          sketchId: null,
+          groupId: null,
+          value: 131_259_350_503.858_64,
+        },
+        {
+          geographyId: "eez",
+          metricId: "count",
+          classId: "global-eez-mr-v12-california", // Formatted correctly
+          sketchId: null,
+          groupId: null,
+          value: 1,
+        },
+      ]),
+    });
+
+    const cleanMetrics = precalcCleanup(projectClient);
+    expect(cleanMetrics.length).toBe(3);
+    cleanMetrics.forEach((m: Metric) => {
+      expect(m.classId).not.toBe("global-eez-mr-v12");
+    });
+  });
 });

--- a/packages/geoprocessing/scripts/base/datasources/precalcCleanup.ts
+++ b/packages/geoprocessing/scripts/base/datasources/precalcCleanup.ts
@@ -19,11 +19,10 @@ export function precalcCleanup<C extends ProjectClientBase>(
       curGeog = projectClient.getGeographyById(m.geographyId);
       if (!curGeog) return false;
 
-      // precalc metrics should have a classId ending in -total
-      if (m.classId.endsWith("-total") === false) {
-        return false;
-      }
-      const datasourceId = m.classId.replace("-total", "");
+      // precalc metrics should have the format: "datasourceId-class"
+      if (!m.classId.includes("-")) return false;
+
+      const datasourceId = m.classId.slice(0, m.classId.lastIndexOf("-"));
       curDatasource = projectClient.getDatasourceById(datasourceId);
       if (!curDatasource) return false;
       if (curGeog.precalc === false && curDatasource.precalc === false)


### PR DESCRIPTION
Previously, any precalc metric that didn't end in `-total` was removed in cleanup. This discarded vector datasources with classes `benthic-coral` and categorical rasters `kelpPersist-1` precalc metrics incorrectly. 

Tested with gp `7.0.0-experimental-precalcClean.2` and working as expected in `california-reports`