### PR TITLE
Fix multiple choice sketch attributes bug

### DIFF
--- a/packages/geoprocessing/src/components/SketchAttributesCard.tsx
+++ b/packages/geoprocessing/src/components/SketchAttributesCard.tsx
@@ -126,7 +126,16 @@ export const SketchAttributesCard = ({
                       paddingLeft: 6,
                     }}
                   >
-                    {t(valueLabel) /* i18next-extract-disable-line */}
+                    {valueLabel
+                      ? Array.isArray(valueLabel)
+                        ? valueLabel.map((v, index) => (
+                            <React.Fragment key={index}>
+                              {t(v)}
+                              <br />
+                            </React.Fragment>
+                          ))
+                        : t(valueLabel) /* i18next-extract-disable-line */
+                      : "N/A"}
                   </td>
                   {/* <span>{attr.label}</span>=<span>{attr.value}</span> */}
                 </tr>

--- a/packages/geoprocessing/src/components/SketchAttributesCard.tsx
+++ b/packages/geoprocessing/src/components/SketchAttributesCard.tsx
@@ -129,10 +129,7 @@ export const SketchAttributesCard = ({
                     {valueLabel
                       ? Array.isArray(valueLabel)
                         ? valueLabel.map((v, index) => (
-                            <React.Fragment key={index}>
-                              {t(v)}
-                              <br />
-                            </React.Fragment>
+                            <div key={index}>{t(v)}</div>
                           ))
                         : t(valueLabel) /* i18next-extract-disable-line */
                       : "N/A"}

--- a/packages/geoprocessing/src/components/SketchAttributesNextCard.stories.tsx
+++ b/packages/geoprocessing/src/components/SketchAttributesNextCard.stories.tsx
@@ -67,6 +67,20 @@ const nextContextValue = sampleSketchReportContextValue({
           },
         },
       },
+      {
+        label: "Gears",
+        value: ["LONG_LINE", "TRAWL"],
+        exportId: "gears",
+        fieldType: "MultipleChoice",
+        valueLabel: ["Long Line", "Trawl"],
+        formElementId: 2300,
+        alternateLanguages: {
+          pt: {
+            label: "Engrenagens",
+            valueLabel: ["Linha Longa", "Arrasto"],
+          },
+        },
+      },
     ],
   },
 });


### PR DESCRIPTION
When multiple options are selected for sketch attributes, the sketch attribute card previously only showed one of the selected choices. Needed update to properly display the array of selected options.