### PR TITLE
Delete chunked cache results on clear:results

### DIFF
--- a/packages/geoprocessing/src/aws/dynamodb/scanTasks.ts
+++ b/packages/geoprocessing/src/aws/dynamodb/scanTasks.ts
@@ -27,10 +27,11 @@ export function scanTasks(
     query = {
       TableName: tableName,
       ProjectionExpression: "id, service",
-      FilterExpression: "service = :exactService OR begins_with(service, :servicePrefix)",
+      FilterExpression:
+        "service = :serviceName OR begins_with(service, :serviceNameChunked)",
       ExpressionAttributeValues: {
-        ":exactService": serviceName,
-        ":servicePrefix": `${serviceName}-chunk`,
+        ":serviceName": serviceName,
+        ":serviceNameChunked": `${serviceName}-chunk`,
       },
     };
   }

--- a/packages/geoprocessing/src/aws/dynamodb/scanTasks.ts
+++ b/packages/geoprocessing/src/aws/dynamodb/scanTasks.ts
@@ -27,9 +27,10 @@ export function scanTasks(
     query = {
       TableName: tableName,
       ProjectionExpression: "id, service",
-      FilterExpression: "service = :pk",
+      FilterExpression: "service = :exactService OR begins_with(service, :servicePrefix)",
       ExpressionAttributeValues: {
-        ":pk": serviceName,
+        ":exactService": serviceName,
+        ":servicePrefix": `${serviceName}-chunk`,
       },
     };
   }


### PR DESCRIPTION
Closes #366 

When the user ran `clear:results` and specified a report, i.e. `depth`, current behavior is to pull down all cached results with the service `depth` to delete. This works when cached results are small enough that they only require one cache table entry. When cached results are larger, the results are split over multiple entries in chunks and the service named becomes `depth-chunk-0`, `depth-chunk-1`, etc. 

Now `clear:results` will select items from the cache table with an exact match (`depth`) AND chunked results (`depth-chunk*`)

