### PR TITLE
callWithRetry updates, add back node-fetch polyfill due to unsolved SocketClosed error

### DIFF
--- a/packages/geoprocessing/src/dataproviders/cog.ts
+++ b/packages/geoprocessing/src/dataproviders/cog.ts
@@ -11,6 +11,6 @@ import { callWithRetry } from "../helpers/callWithRetry.js";
 export const loadCog = async (url: string) => {
   if (process.env.NODE_ENV !== "test") console.log("loadCog", url);
   return await callWithRetry(geoblaze.parse, [url], {
-    ifErrorMsgContains: "SocketError",
+    ifErrorMsgContains: "fetch failed",
   });
 };

--- a/packages/geoprocessing/src/dataproviders/cog.ts
+++ b/packages/geoprocessing/src/dataproviders/cog.ts
@@ -10,5 +10,7 @@ import { callWithRetry } from "../helpers/callWithRetry.js";
  */
 export const loadCog = async (url: string) => {
   if (process.env.NODE_ENV !== "test") console.log("loadCog", url);
-  return await callWithRetry(geoblaze.parse, [url]);
+  return await callWithRetry(geoblaze.parse, [url], {
+    ifErrorMsgContains: "SocketError",
+  });
 };

--- a/packages/geoprocessing/src/dataproviders/cog.ts
+++ b/packages/geoprocessing/src/dataproviders/cog.ts
@@ -1,5 +1,6 @@
 import geoblaze from "geoblaze";
 import { callWithRetry } from "../helpers/callWithRetry.js";
+import "./fetchPolyfill.js";
 
 /**
  * Returns cog-aware georaster at given url.  If fetch fails, will retry up to 3 times

--- a/packages/geoprocessing/src/dataproviders/flatgeobuf.ts
+++ b/packages/geoprocessing/src/dataproviders/flatgeobuf.ts
@@ -64,7 +64,7 @@ export async function loadFgb<F extends Feature<Geometry>>(
 
   // retry up to 3 times if SocketError
   const features: F[] = (await callWithRetry(takeFeatures, [url, fgBox], {
-    ifErrorMsgContains: "SocketError",
+    ifErrorMsgContains: "fetch failed",
   })) as F[];
 
   if (!Array.isArray(features))

--- a/packages/geoprocessing/src/dataproviders/flatgeobuf.ts
+++ b/packages/geoprocessing/src/dataproviders/flatgeobuf.ts
@@ -4,6 +4,7 @@ import { takeAsync } from "flatgeobuf/lib/mjs/streams/utils.js";
 import { deserialize } from "flatgeobuf/lib/mjs/geojson.js";
 import { BBox, Feature, FeatureCollection, Geometry } from "../types/index.js";
 import { callWithRetry } from "../helpers/callWithRetry.js";
+import "./fetchPolyfill.js";
 
 export interface FgBoundingBox {
   minX: number;

--- a/packages/geoprocessing/src/dataproviders/flatgeobuf.ts
+++ b/packages/geoprocessing/src/dataproviders/flatgeobuf.ts
@@ -62,11 +62,10 @@ export async function loadFgb<F extends Feature<Geometry>>(
   const takeFeatures = (url: string, fgBox: FgBoundingBox) =>
     takeAsync(deserialize(url, fgBox) as AsyncGenerator);
 
-  // retry up to 3 times if fetch fails
-  const features: F[] = (await callWithRetry(takeFeatures, [
-    url,
-    fgBox,
-  ])) as F[];
+  // retry up to 3 times if SocketError
+  const features: F[] = (await callWithRetry(takeFeatures, [url, fgBox], {
+    ifErrorMsgContains: "SocketError",
+  })) as F[];
 
   if (!Array.isArray(features))
     throw new Error("Unexpected result from loadFgb");

--- a/packages/geoprocessing/src/helpers/callWithRetry.test.ts
+++ b/packages/geoprocessing/src/helpers/callWithRetry.test.ts
@@ -11,7 +11,7 @@ describe("callWithRetry", () => {
   test("should retry on first fail and succeed the second try", async () => {
     const fn = vi
       .fn()
-      .mockRejectedValueOnce(new Error("SocketError"))
+      .mockRejectedValueOnce(new Error("fetch failed"))
       .mockResolvedValueOnce("success");
     const result = await callWithRetry(fn, []);
     expect(result).toBe("success");
@@ -21,24 +21,24 @@ describe("callWithRetry", () => {
   test("errorSubstring should rethrow OtherError and retry SocketError", async () => {
     const fn = vi.fn().mockRejectedValueOnce(new Error("OtherError"));
     await expect(
-      callWithRetry(fn, [], { ifErrorMsgContains: "SocketError" }),
+      callWithRetry(fn, [], { ifErrorMsgContains: "fetch failed" }),
     ).rejects.toThrowError();
     expect(fn).toHaveBeenCalledTimes(1);
 
     const socketErrorFn = vi
       .fn()
-      .mockRejectedValueOnce(new Error("SocketError"))
+      .mockRejectedValueOnce(new Error("fetch failed"))
       .mockResolvedValueOnce("success");
     const result = await callWithRetry(socketErrorFn, [], {
-      ifErrorMsgContains: "SocketError",
+      ifErrorMsgContains: "fetch failed",
     });
     expect(result).toBe("success");
     expect(socketErrorFn).toHaveBeenCalledTimes(2);
   });
 
   test("should fail all retry attempts", async () => {
-    const fn = vi.fn().mockRejectedValue(new Error("SocketError"));
-    await expect(callWithRetry(fn, [])).rejects.toThrow("SocketError");
+    const fn = vi.fn().mockRejectedValue(new Error("fetch failed"));
+    await expect(callWithRetry(fn, [])).rejects.toThrow("fetch failed");
     expect(fn).toHaveBeenCalledTimes(4);
   });
 });

--- a/packages/geoprocessing/src/helpers/callWithRetry.test.ts
+++ b/packages/geoprocessing/src/helpers/callWithRetry.test.ts
@@ -39,6 +39,6 @@ describe("callWithRetry", () => {
   test("should fail all retry attempts", async () => {
     const fn = vi.fn().mockRejectedValue(new Error("fetch failed"));
     await expect(callWithRetry(fn, [])).rejects.toThrow("fetch failed");
-    expect(fn).toHaveBeenCalledTimes(4);
-  });
+    expect(fn).toHaveBeenCalledTimes(5);
+  }, 10_000);
 });

--- a/packages/geoprocessing/src/helpers/callWithRetry.test.ts
+++ b/packages/geoprocessing/src/helpers/callWithRetry.test.ts
@@ -39,6 +39,6 @@ describe("callWithRetry", () => {
   test("should fail all retry attempts", async () => {
     const fn = vi.fn().mockRejectedValue(new Error("fetch failed"));
     await expect(callWithRetry(fn, [])).rejects.toThrow("fetch failed");
-    expect(fn).toHaveBeenCalledTimes(5);
+    expect(fn).toHaveBeenCalledTimes(4);
   }, 10_000);
 });

--- a/packages/geoprocessing/src/helpers/callWithRetry.test.ts
+++ b/packages/geoprocessing/src/helpers/callWithRetry.test.ts
@@ -1,6 +1,6 @@
 import { describe, test, expect, vi } from "vitest";
 import { callWithRetry } from "./callWithRetry.js";
-describe("retry", () => {
+describe("callWithRetry", () => {
   test("should succeed on the first try", async () => {
     const fn = vi.fn().mockResolvedValue("success");
     const result = await callWithRetry(fn, []);
@@ -8,19 +8,37 @@ describe("retry", () => {
     expect(fn).toHaveBeenCalledTimes(1);
   });
 
-  test("should fail the first time and succeed the second time", async () => {
+  test("should retry on first fail and succeed the second try", async () => {
     const fn = vi
       .fn()
-      .mockRejectedValueOnce(new Error("first failure"))
+      .mockRejectedValueOnce(new Error("SocketError"))
       .mockResolvedValueOnce("success");
     const result = await callWithRetry(fn, []);
     expect(result).toBe("success");
     expect(fn).toHaveBeenCalledTimes(2);
   });
 
+  test("errorSubstring should rethrow OtherError and retry SocketError", async () => {
+    const fn = vi.fn().mockRejectedValueOnce(new Error("OtherError"));
+    await expect(
+      callWithRetry(fn, [], { ifErrorMsgContains: "SocketError" }),
+    ).rejects.toThrowError();
+    expect(fn).toHaveBeenCalledTimes(1);
+
+    const socketErrorFn = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("SocketError"))
+      .mockResolvedValueOnce("success");
+    const result = await callWithRetry(socketErrorFn, [], {
+      ifErrorMsgContains: "SocketError",
+    });
+    expect(result).toBe("success");
+    expect(socketErrorFn).toHaveBeenCalledTimes(2);
+  });
+
   test("should fail all retry attempts", async () => {
-    const fn = vi.fn().mockRejectedValue(new Error("failure"));
-    await expect(callWithRetry(fn, [])).rejects.toThrow("failure");
+    const fn = vi.fn().mockRejectedValue(new Error("SocketError"));
+    await expect(callWithRetry(fn, [])).rejects.toThrow("SocketError");
     expect(fn).toHaveBeenCalledTimes(4);
   });
 });

--- a/packages/geoprocessing/src/helpers/callWithRetry.ts
+++ b/packages/geoprocessing/src/helpers/callWithRetry.ts
@@ -19,7 +19,7 @@ export async function callWithRetry<T extends (...arg0: any[]) => any>(
   } = {},
 ): Promise<Awaited<ReturnType<T>>> {
   const {
-    maxTry = 4,
+    maxTry = 3,
     retryCount = 1,
     logEachFailure = true,
     ifErrorMsgContains: errorFilter,

--- a/packages/geoprocessing/src/helpers/callWithRetry.ts
+++ b/packages/geoprocessing/src/helpers/callWithRetry.ts
@@ -1,10 +1,11 @@
 /**
- * Calls given function and if throws error it recursively retries up to maxTry times
+ * Calls given function and if error thrown, it recursively retries function up to maxTry times, then just rethrows the error
  * @param fn the function to call
  * @param args arguments to pass to the function when it is called
  * @param options.maxTry the maximum number of times to try again, defaults to 3
  * @param options.retryCount the current retry count, defaults to 1
  * @param options.logEachFailure whether to console.log each failure, defaults to true
+ * @param options.ifErrorContains if provided, retries only if error message includes this string, otherwise rethrows immediatly.
  * @returns the result of calling the function
  */
 export async function callWithRetry<T extends (...arg0: any[]) => any>(
@@ -14,20 +15,36 @@ export async function callWithRetry<T extends (...arg0: any[]) => any>(
     maxTry?: number;
     retryCount?: number;
     logEachFailure?: boolean;
+    ifErrorMsgContains?: string;
   } = {},
 ): Promise<Awaited<ReturnType<T>>> {
-  const { maxTry = 3, retryCount = 1, logEachFailure = true } = options;
+  const {
+    maxTry = 3,
+    retryCount = 1,
+    logEachFailure = true,
+    ifErrorMsgContains: errorFilter,
+  } = options;
   const currRetry = typeof retryCount === "number" ? retryCount : 1;
   try {
     const result = await fn(...args);
     return result;
-  } catch (error) {
-    if (logEachFailure) console.log(`Retry ${currRetry} failed.`);
-    if (currRetry > maxTry) {
-      console.log(`All ${maxTry} retry attempts exhausted`);
+  } catch (error: unknown) {
+    if (error instanceof Error) {
+      // if error message does not include errorMsgSubstring, rethrow
+      if (errorFilter && !error.message.includes(errorFilter)) {
+        throw error;
+      }
+      if (logEachFailure) {
+        console.log(`Retry ${currRetry} failed`);
+        console.log(error.message);
+      }
+      if (currRetry > maxTry) {
+        console.log(`All ${maxTry} retry attempts exhausted`);
+        throw error;
+      }
+      return callWithRetry(fn, args, { maxTry, retryCount: currRetry + 1 });
+    } else {
       throw error;
     }
-
-    return callWithRetry(fn, args, { maxTry, retryCount: currRetry + 1 });
   }
 }

--- a/packages/geoprocessing/src/helpers/callWithRetry.ts
+++ b/packages/geoprocessing/src/helpers/callWithRetry.ts
@@ -19,7 +19,7 @@ export async function callWithRetry<T extends (...arg0: any[]) => any>(
   } = {},
 ): Promise<Awaited<ReturnType<T>>> {
   const {
-    maxTry = 3,
+    maxTry = 4,
     retryCount = 1,
     logEachFailure = true,
     ifErrorMsgContains: errorFilter,
@@ -42,6 +42,10 @@ export async function callWithRetry<T extends (...arg0: any[]) => any>(
         console.log(`All ${maxTry} retry attempts exhausted`);
         throw error;
       }
+      // Wait with exponential backoff
+      const waitTime = Math.pow(2, currRetry) * 200; // Exponential backoff
+      await new Promise((resolve) => setTimeout(resolve, waitTime));
+      // Try again
       return callWithRetry(fn, args, { maxTry, retryCount: currRetry + 1 });
     } else {
       throw error;

--- a/packages/geoprocessing/src/toolbox/geoblaze/geoblaze.test.e2e.ts
+++ b/packages/geoprocessing/src/toolbox/geoblaze/geoblaze.test.e2e.ts
@@ -82,8 +82,14 @@ describe("geoblaze cog test", () => {
     };
     try {
       await geoblaze.sum(url, feature);
-    } catch {
-      return;
+    } catch (error: unknown) {
+      if (typeof error === "string") {
+        expect(
+          error.includes("No Values were found in the given geometry"),
+        ).toEqual(true);
+        return;
+      }
+      throw error;
     }
     throw new Error("should not reach here, feature smaller than pixel");
   });

--- a/packages/geoprocessing/src/toolbox/geoblaze/geoblaze.ts
+++ b/packages/geoprocessing/src/toolbox/geoblaze/geoblaze.ts
@@ -42,7 +42,7 @@ export const getSum = async (
   const finalFeat = toRasterProjection(raster, feat);
   try {
     const result = await callWithRetry(geoblaze.sum, [raster, finalFeat], {
-      ifErrorMsgContains: "SocketError",
+      ifErrorMsgContains: "fetch failed",
     });
     sum = result[0];
   } catch {
@@ -75,7 +75,7 @@ export const getArea = async (
           stats: ["valid"],
         },
       ],
-      { ifErrorMsgContains: "SocketError" },
+      { ifErrorMsgContains: "fetch failed" },
     );
     area =
       Number.parseInt(result[0].valid) * raster.pixelHeight * raster.pixelWidth;
@@ -108,7 +108,7 @@ export const getHistogram = async (
   try {
     histogram = (
       await callWithRetry(geoblaze.histogram, [raster, feat, options], {
-        ifErrorMsgContains: "SocketError",
+        ifErrorMsgContains: "fetch failed",
       })
     )[0];
   } catch {

--- a/packages/geoprocessing/src/toolbox/geoblaze/geoblaze.ts
+++ b/packages/geoprocessing/src/toolbox/geoblaze/geoblaze.ts
@@ -41,7 +41,9 @@ export const getSum = async (
   let sum = 0;
   const finalFeat = toRasterProjection(raster, feat);
   try {
-    const result = await callWithRetry(geoblaze.sum, [raster, finalFeat]);
+    const result = await callWithRetry(geoblaze.sum, [raster, finalFeat], {
+      ifErrorMsgContains: "SocketError",
+    });
     sum = result[0];
   } catch {
     console.log(
@@ -64,13 +66,17 @@ export const getArea = async (
   const finalFeat = toRasterProjection(raster, feat);
   try {
     // undocumented shortcut lets you pass a test/filter function to stats
-    const result = await callWithRetry(geoblaze.stats, [
-      raster,
-      finalFeat,
-      {
-        stats: ["valid"],
-      },
-    ]);
+    const result = await callWithRetry(
+      geoblaze.stats,
+      [
+        raster,
+        finalFeat,
+        {
+          stats: ["valid"],
+        },
+      ],
+      { ifErrorMsgContains: "SocketError" },
+    );
     area =
       Number.parseInt(result[0].valid) * raster.pixelHeight * raster.pixelWidth;
   } catch {
@@ -101,7 +107,9 @@ export const getHistogram = async (
   let histogram = {};
   try {
     histogram = (
-      await callWithRetry(geoblaze.histogram, [raster, feat, options])
+      await callWithRetry(geoblaze.histogram, [raster, feat, options], {
+        ifErrorMsgContains: "SocketError",
+      })
     )[0];
   } catch {
     console.log(

--- a/packages/geoprocessing/src/toolbox/geoblaze/rasterStats.ts
+++ b/packages/geoprocessing/src/toolbox/geoblaze/rasterStats.ts
@@ -176,12 +176,20 @@ export const rasterStats = async (
       // Transfer calculated stats if valid number
       finalStats.push(finalStatsBand);
     }
-  } catch {
-    if (process.env.NODE_ENV !== "test")
-      console.log(
-        "overlapRaster geoblaze.stats threw, meaning no cells with value were found within the geometry",
-      );
-    return defaultStats;
+  } catch (error: unknown) {
+    // only catch error if no raster cells with value found in geometry
+    if (
+      typeof error === "string" &&
+      error.includes("No Values were found in the given geometry")
+    ) {
+      if (process.env.NODE_ENV !== "test")
+        console.log(
+          "overlapRaster geoblaze.stats threw, meaning no cells with value were found within the geometry",
+        );
+      return defaultStats;
+    } else {
+      throw error;
+    }
   }
 
   return finalStats;

--- a/packages/geoprocessing/src/toolbox/geoblaze/rasterStats.ts
+++ b/packages/geoprocessing/src/toolbox/geoblaze/rasterStats.ts
@@ -190,7 +190,7 @@ export const rasterStats = async (
       return defaultStats;
     } else {
       console.log("rasterStats error", JSON.stringify(error, null, 2));
-      throw error;
+      // throw error;
     }
   }
 

--- a/packages/geoprocessing/src/toolbox/geoblaze/rasterStats.ts
+++ b/packages/geoprocessing/src/toolbox/geoblaze/rasterStats.ts
@@ -111,7 +111,7 @@ export const rasterStats = async (
           },
         ],
         {
-          ifErrorMsgContains: "SocketError",
+          ifErrorMsgContains: "fetch failed",
         },
       )) as Histogram[];
 
@@ -146,7 +146,7 @@ export const rasterStats = async (
           },
           filterFn,
         ],
-        { ifErrorMsgContains: "SocketError" },
+        { ifErrorMsgContains: "fetch failed" },
       );
     }
 
@@ -189,6 +189,7 @@ export const rasterStats = async (
         );
       return defaultStats;
     } else {
+      console.log("rasterStats error", JSON.stringify(error, null, 2));
       throw error;
     }
   }

--- a/packages/geoprocessing/src/toolbox/geoblaze/rasterStats.ts
+++ b/packages/geoprocessing/src/toolbox/geoblaze/rasterStats.ts
@@ -100,13 +100,19 @@ export const rasterStats = async (
 
   try {
     if (categorical) {
-      const histogram = (await callWithRetry(geoblaze.histogram, [
-        raster,
-        projectedFeat,
+      const histogram = (await callWithRetry(
+        geoblaze.histogram,
+        [
+          raster,
+          projectedFeat,
+          {
+            scaleType: "nominal",
+          },
+        ],
         {
-          scaleType: "nominal",
+          ifErrorMsgContains: "SocketError",
         },
-      ])) as Histogram[];
+      )) as Histogram[];
 
       // If no overlap, return default values
       if (
@@ -126,17 +132,21 @@ export const rasterStats = async (
         });
       }
     } else {
-      statsByBand = await callWithRetry(geoblaze.stats, [
-        raster,
-        projectedFeat,
-        {
-          stats: statsToCalculate.filter((stat) =>
-            GEOBLAZE_RASTER_STATS.includes(stat),
-          ), // filter to only native geoblaze stats
-          ...restCalcOptions,
-        },
-        filterFn,
-      ]);
+      statsByBand = await callWithRetry(
+        geoblaze.stats,
+        [
+          raster,
+          projectedFeat,
+          {
+            stats: statsToCalculate.filter((stat) =>
+              GEOBLAZE_RASTER_STATS.includes(stat),
+            ), // filter to only native geoblaze stats
+            ...restCalcOptions,
+          },
+          filterFn,
+        ],
+        { ifErrorMsgContains: "SocketError" },
+      );
     }
 
     for (const statBand of statsByBand) {

--- a/packages/geoprocessing/src/toolbox/geoblaze/rasterStats.ts
+++ b/packages/geoprocessing/src/toolbox/geoblaze/rasterStats.ts
@@ -51,7 +51,8 @@ export interface RasterStatsOptions extends CalcStatsOptions {
 /**
  * Calculates over 10 different raster statistics, optionally constrains to raster cells overlapping with feature (zonal statistics).
  * Defaults to calculating only sum stat
- * If no cells found, returns 0 or null value for each stat as appropriate.
+ * If no raster cells with value found, returns 0 or null value for each stat as appropriate.
+ * @throws any errors
  */
 export const rasterStats = async (
   raster: Georaster,

--- a/packages/geoprocessing/src/toolbox/geoblaze/rasterStats.ts
+++ b/packages/geoprocessing/src/toolbox/geoblaze/rasterStats.ts
@@ -178,26 +178,30 @@ export const rasterStats = async (
       finalStats.push(finalStatsBand);
     }
   } catch (error: unknown) {
-    // only catch error if no raster cells with value found in geometry
+    // swallow certain errors and return default stats instead of rethrowing
     if (
       typeof error === "string" &&
       error.includes("No Values were found in the given geometry")
     ) {
-      if (process.env.NODE_ENV !== "test")
-        console.log(
-          "overlapRaster geoblaze.stats threw, meaning no cells with value were found within the geometry",
-        );
+      console.log("rasterStats returning default values for error:", error);
       return defaultStats;
     }
 
-    // Log more information about errors so we can better catch them.
-    if (error instanceof Error) {
-      console.log("rasterStats error", error.message);
+    if (
+      error instanceof Error &&
+      error.message.includes(
+        "Cannot read properties of undefined (reading 'vrm')",
+      )
+    ) {
+      console.log(
+        "rasterStats returning default values for error:",
+        error.message,
+      );
+      return defaultStats;
     }
 
-    // temporarily swallow error and return default values instead of rethrowing
-    return defaultStats;
-    // throw error;
+    // rethrow all other errors
+    throw error;
   }
 
   return finalStats;

--- a/packages/geoprocessing/src/toolbox/geoblaze/rasterStats.ts
+++ b/packages/geoprocessing/src/toolbox/geoblaze/rasterStats.ts
@@ -188,10 +188,14 @@ export const rasterStats = async (
           "overlapRaster geoblaze.stats threw, meaning no cells with value were found within the geometry",
         );
       return defaultStats;
-    } else {
-      console.log("rasterStats error", JSON.stringify(error, null, 2));
-      // throw error;
     }
+
+    // Log more information about errors so we can better catch them.
+    console.log("rasterStats error", JSON.stringify(error, null, 2));
+
+    // temporarily swallow error and return default values instead of rethrowing
+    return defaultStats;
+    // throw error;
   }
 
   return finalStats;

--- a/packages/geoprocessing/src/toolbox/geoblaze/rasterStats.ts
+++ b/packages/geoprocessing/src/toolbox/geoblaze/rasterStats.ts
@@ -183,7 +183,10 @@ export const rasterStats = async (
       typeof error === "string" &&
       error.includes("No Values were found in the given geometry")
     ) {
-      console.log("rasterStats returning default values for error:", error);
+      console.log(
+        "rasterStats returning default values for error:",
+        "No Values were found in the given geometry",
+      );
       return defaultStats;
     }
 
@@ -195,7 +198,7 @@ export const rasterStats = async (
     ) {
       console.log(
         "rasterStats returning default values for error:",
-        error.message,
+        "Cannot read properties of undefined (reading 'vrm')",
       );
       return defaultStats;
     }

--- a/packages/geoprocessing/src/toolbox/geoblaze/rasterStats.ts
+++ b/packages/geoprocessing/src/toolbox/geoblaze/rasterStats.ts
@@ -191,7 +191,9 @@ export const rasterStats = async (
     }
 
     // Log more information about errors so we can better catch them.
-    console.log("rasterStats error", JSON.stringify(error, null, 2));
+    if (error instanceof Error) {
+      console.log("rasterStats error", error.message);
+    }
 
     // temporarily swallow error and return default values instead of rethrowing
     return defaultStats;

--- a/website/docs/api/client-core/index.md
+++ b/website/docs/api/client-core/index.md
@@ -79,6 +79,12 @@ Re-exports [CalcStatsOptions](../geoprocessing/interfaces/CalcStatsOptions.md)
 
 ***
 
+### callWithRetry
+
+Re-exports [callWithRetry](../geoprocessing/functions/callWithRetry.md)
+
+***
+
 ### capitalize
 
 Re-exports [capitalize](../geoprocessing/functions/capitalize.md)

--- a/website/docs/api/geoprocessing/functions/callWithRetry.md
+++ b/website/docs/api/geoprocessing/functions/callWithRetry.md
@@ -1,0 +1,34 @@
+# callWithRetry()
+
+```ts
+function callWithRetry<T>(
+   fn, 
+   args, 
+options): Promise<Awaited<ReturnType<T>>>
+```
+
+Calls given function and if error thrown, it recursively retries function up to maxTry times, then just rethrows the error
+
+## Type Parameters
+
+| Type Parameter |
+| ------ |
+| `T` *extends* (...`arg0`) => `any` |
+
+## Parameters
+
+| Parameter | Type | Description |
+| ------ | ------ | ------ |
+| `fn` | `T` | the function to call |
+| `args` | `Parameters`\<`T`\> | arguments to pass to the function when it is called |
+| `options` | `object` | - |
+| `options.ifErrorMsgContains`? | `string` | - |
+| `options.logEachFailure`? | `boolean` | whether to console.log each failure, defaults to true |
+| `options.maxTry`? | `number` | the maximum number of times to try again, defaults to 3 |
+| `options.retryCount`? | `number` | the current retry count, defaults to 1 |
+
+## Returns
+
+`Promise`\<`Awaited`\<`ReturnType`\<`T`\>\>\>
+
+the result of calling the function

--- a/website/docs/api/geoprocessing/functions/rasterStats.md
+++ b/website/docs/api/geoprocessing/functions/rasterStats.md
@@ -6,7 +6,7 @@ function rasterStats(raster, options): Promise<StatsObject[]>
 
 Calculates over 10 different raster statistics, optionally constrains to raster cells overlapping with feature (zonal statistics).
 Defaults to calculating only sum stat
-If no cells found, returns 0 or null value for each stat as appropriate.
+If no raster cells with value found, returns 0 or null value for each stat as appropriate.
 
 ## Parameters
 
@@ -18,3 +18,7 @@ If no cells found, returns 0 or null value for each stat as appropriate.
 ## Returns
 
 `Promise`\<[`StatsObject`](../interfaces/StatsObject.md)[]\>
+
+## Throws
+
+any errors

--- a/website/docs/api/geoprocessing/index.md
+++ b/website/docs/api/geoprocessing/index.md
@@ -107,6 +107,7 @@
 | [bboxOverlap](functions/bboxOverlap.md) | Returns whether bounding box A overlaps with or touches bounding box B |
 | [booleanOverlap](functions/booleanOverlap.md) | Returns all B items that overlap with a A items Not all Feature types are supported, see typedoc A and B must have the same geometry dimension (single or multi). Builds on @turf/boolean-overlap. |
 | [byteSize](functions/byteSize.md) | Get length of string in bytes |
+| [callWithRetry](functions/callWithRetry.md) | Calls given function and if error thrown, it recursively retries function up to maxTry times, then just rethrows the error |
 | [capitalize](functions/capitalize.md) | Capitalizes the first letter of string |
 | [chunk](functions/chunk.md) | Splits an array into chunks of size |
 | [classIdMapping](functions/classIdMapping.md) | Returns mapping of class ID to class DataClass objects |
@@ -265,7 +266,7 @@
 | [randomFloat](functions/randomFloat.md) | - |
 | [randomInt](functions/randomInt.md) | - |
 | [rasterMetrics](functions/rasterMetrics.md) | Calculates summary metrics (stats/area) on given raster, optionally intersecting raster with provided feature (zonal statistics). If feature is a collection, then calculate metrics for each individual feature as well as the collection as a whole. This can be disabled with includeChildMetrics: false. Defaults to assuming a continuous raster but also supports categorical option |
-| [rasterStats](functions/rasterStats.md) | Calculates over 10 different raster statistics, optionally constrains to raster cells overlapping with feature (zonal statistics). Defaults to calculating only sum stat If no cells found, returns 0 or null value for each stat as appropriate. |
+| [rasterStats](functions/rasterStats.md) | Calculates over 10 different raster statistics, optionally constrains to raster cells overlapping with feature (zonal statistics). Defaults to calculating only sum stat If no raster cells with value found, returns 0 or null value for each stat as appropriate. |
 | [rasterStatsToMetrics](functions/rasterStatsToMetrics.md) | Converts an array of geoblaze raster StatsObject to an array of Metrics |
 | [rbcsMpaToMetric](functions/rbcsMpaToMetric.md) | - |
 | [rbcsZoneToMetric](functions/rbcsZoneToMetric.md) | Transforms an rbcs zone object to a metric |

--- a/website/docs/api/typedoc-sidebar.cjs
+++ b/website/docs/api/typedoc-sidebar.cjs
@@ -1288,6 +1288,11 @@ const typedocSidebar = { items: [
           },
           {
             "type": "doc",
+            "id": "api/geoprocessing/functions/callWithRetry",
+            "label": "callWithRetry"
+          },
+          {
+            "type": "doc",
             "id": "api/geoprocessing/functions/capitalize",
             "label": "capitalize"
           },


### PR DESCRIPTION
- callWithRetry
  - add optional ifErrorMsgContains string, will now retry unless error message contains that string.
  - add exponential backoff so that there is a an increasing wait before the next retry.
- rasterStats will now catch geoblaze vrm error when passing zeroSketch, and return rasterStat default values in that case, rethrow all other errors.
- add back node-fetch polyfill to cog and flatgeobuf to solve SocketError showing up during high volume network call situation (e.g. smoke tests).