### PR TITLE
Make datasets bucket private

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1395,6 +1395,175 @@
         "node": ">=18.0.0"
       }
     },
+    "node_modules/@aws-sdk/s3-request-presigner": {
+      "version": "3.930.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/s3-request-presigner/-/s3-request-presigner-3.930.0.tgz",
+      "integrity": "sha512-kIjYM2a3xkg5Ll8TUBVjE5mM/uTswE6JycUsND7y3nbEHUd7OXBShAspFZxgTjga33bsdaIRbggligC8tu25pg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/signature-v4-multi-region": "3.930.0",
+        "@aws-sdk/types": "3.930.0",
+        "@aws-sdk/util-format-url": "3.930.0",
+        "@smithy/middleware-endpoint": "^4.3.9",
+        "@smithy/protocol-http": "^5.3.5",
+        "@smithy/smithy-client": "^4.9.5",
+        "@smithy/types": "^4.9.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/s3-request-presigner/node_modules/@aws-sdk/core": {
+      "version": "3.930.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.930.0.tgz",
+      "integrity": "sha512-E95pWT1ayfRWg0AW2KNOCYM7QQcVeOhMRLX5PXLeDKcdxP7s3x0LHG9t7a3nPbAbvYLRrhC7O2lLWzzMCpqjsw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.930.0",
+        "@aws-sdk/xml-builder": "3.930.0",
+        "@smithy/core": "^3.18.2",
+        "@smithy/node-config-provider": "^4.3.5",
+        "@smithy/property-provider": "^4.2.5",
+        "@smithy/protocol-http": "^5.3.5",
+        "@smithy/signature-v4": "^5.3.5",
+        "@smithy/smithy-client": "^4.9.5",
+        "@smithy/types": "^4.9.0",
+        "@smithy/util-base64": "^4.3.0",
+        "@smithy/util-middleware": "^4.2.5",
+        "@smithy/util-utf8": "^4.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/s3-request-presigner/node_modules/@aws-sdk/middleware-sdk-s3": {
+      "version": "3.930.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.930.0.tgz",
+      "integrity": "sha512-bnVK0xVVmrPyKTbV5MgG6KP7MPe87GngBPD5MrYj9kWmGrJIvnt0qer0UIgWAnsyCi7XrTfw7SMgYRpSxOYEMw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "3.930.0",
+        "@aws-sdk/types": "3.930.0",
+        "@aws-sdk/util-arn-parser": "3.893.0",
+        "@smithy/core": "^3.18.2",
+        "@smithy/node-config-provider": "^4.3.5",
+        "@smithy/protocol-http": "^5.3.5",
+        "@smithy/signature-v4": "^5.3.5",
+        "@smithy/smithy-client": "^4.9.5",
+        "@smithy/types": "^4.9.0",
+        "@smithy/util-config-provider": "^4.2.0",
+        "@smithy/util-middleware": "^4.2.5",
+        "@smithy/util-stream": "^4.5.6",
+        "@smithy/util-utf8": "^4.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/s3-request-presigner/node_modules/@aws-sdk/signature-v4-multi-region": {
+      "version": "3.930.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.930.0.tgz",
+      "integrity": "sha512-UOAq1ftbrZc9HRP/nG970OONNykIDWunjth9GvGDODkW0FR7DHJWBmTwj61ZnrSiuSParp1eQfa+JsZ8eXNPcw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/middleware-sdk-s3": "3.930.0",
+        "@aws-sdk/types": "3.930.0",
+        "@smithy/protocol-http": "^5.3.5",
+        "@smithy/signature-v4": "^5.3.5",
+        "@smithy/types": "^4.9.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/s3-request-presigner/node_modules/@aws-sdk/types": {
+      "version": "3.930.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.930.0.tgz",
+      "integrity": "sha512-we/vaAgwlEFW7IeftmCLlLMw+6hFs3DzZPJw7lVHbj/5HJ0bz9gndxEsS2lQoeJ1zhiiLqAqvXxmM43s0MBg0A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.9.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/s3-request-presigner/node_modules/@aws-sdk/util-arn-parser": {
+      "version": "3.893.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-arn-parser/-/util-arn-parser-3.893.0.tgz",
+      "integrity": "sha512-u8H4f2Zsi19DGnwj5FSZzDMhytYF/bCh37vAtBsn3cNDL3YG578X5oc+wSX54pM3tOxS+NY7tvOAo52SW7koUA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/s3-request-presigner/node_modules/@aws-sdk/xml-builder": {
+      "version": "3.930.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.930.0.tgz",
+      "integrity": "sha512-YIfkD17GocxdmlUVc3ia52QhcWuRIUJonbF8A2CYfcWNV3HzvAqpcPeC0bYUhkK+8e8YO1ARnLKZQE0TlwzorA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.9.0",
+        "fast-xml-parser": "5.2.5",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/s3-request-presigner/node_modules/@smithy/node-config-provider": {
+      "version": "4.3.5",
+      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-4.3.5.tgz",
+      "integrity": "sha512-UTurh1C4qkVCtqggI36DGbLB2Kv8UlcFdMXDcWMbqVY2uRg0XmT9Pb4Vj6oSQ34eizO1fvR0RnFV4Axw4IrrAg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/property-provider": "^4.2.5",
+        "@smithy/shared-ini-file-loader": "^4.4.0",
+        "@smithy/types": "^4.9.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/s3-request-presigner/node_modules/fast-xml-parser": {
+      "version": "5.2.5",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.2.5.tgz",
+      "integrity": "sha512-pfX9uG9Ki0yekDHx2SiuRIyFdyAr1kMIMitPvb0YBo8SUfKvia7w7FIyd/l6av85pFYRhZscS75MwMnbvY+hcQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "strnum": "^2.1.0"
+      },
+      "bin": {
+        "fxparser": "src/cli/cli.js"
+      }
+    },
+    "node_modules/@aws-sdk/s3-request-presigner/node_modules/strnum": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.1.1.tgz",
+      "integrity": "sha512-7ZvoFTiCnGxBtDqJ//Cu6fWtZtc7Y3x+QOirG15wztbdngGSkht27o2pyGWrVy0b4WAy3jbKmnoK6g5VlVNUUw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/@aws-sdk/signature-v4-multi-region": {
       "version": "3.744.0",
       "license": "Apache-2.0",
@@ -1466,6 +1635,34 @@
         "@aws-sdk/types": "3.734.0",
         "@smithy/types": "^4.1.0",
         "@smithy/util-endpoints": "^3.0.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-format-url": {
+      "version": "3.930.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-format-url/-/util-format-url-3.930.0.tgz",
+      "integrity": "sha512-FW6Im17Zc7F5WT39XUgDOjtJO95Yu8rsmeRHf7z+Y3FamtTSzH4f713BD/qMyJBrZIlFACWlok/Uuvdl5/qtMg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.930.0",
+        "@smithy/querystring-builder": "^4.2.5",
+        "@smithy/types": "^4.9.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-format-url/node_modules/@aws-sdk/types": {
+      "version": "3.930.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.930.0.tgz",
+      "integrity": "sha512-we/vaAgwlEFW7IeftmCLlLMw+6hFs3DzZPJw7lVHbj/5HJ0bz9gndxEsS2lQoeJ1zhiiLqAqvXxmM43s0MBg0A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.9.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -5613,10 +5810,12 @@
       }
     },
     "node_modules/@smithy/abort-controller": {
-      "version": "4.0.1",
+      "version": "4.2.5",
+      "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-4.2.5.tgz",
+      "integrity": "sha512-j7HwVkBw68YW8UmFRcjZOmssE77Rvk0GWAIN1oFBhsaovQmZWYCIcGa9/pwRB0ExI8Sk9MWNALTjftjHZea7VA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.1.0",
+        "@smithy/types": "^4.9.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -5690,16 +5889,20 @@
       }
     },
     "node_modules/@smithy/core": {
-      "version": "3.1.2",
+      "version": "3.18.3",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.18.3.tgz",
+      "integrity": "sha512-qqpNskkbHOSfrbFbjhYj5o8VMXO26fvN1K/+HbCzUNlTuxgNcPRouUDNm+7D6CkN244WG7aK533Ne18UtJEgAA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/middleware-serde": "^4.0.2",
-        "@smithy/protocol-http": "^5.0.1",
-        "@smithy/types": "^4.1.0",
-        "@smithy/util-body-length-browser": "^4.0.0",
-        "@smithy/util-middleware": "^4.0.1",
-        "@smithy/util-stream": "^4.0.2",
-        "@smithy/util-utf8": "^4.0.0",
+        "@smithy/middleware-serde": "^4.2.5",
+        "@smithy/protocol-http": "^5.3.5",
+        "@smithy/types": "^4.9.0",
+        "@smithy/util-base64": "^4.3.0",
+        "@smithy/util-body-length-browser": "^4.2.0",
+        "@smithy/util-middleware": "^4.2.5",
+        "@smithy/util-stream": "^4.5.6",
+        "@smithy/util-utf8": "^4.2.0",
+        "@smithy/uuid": "^1.1.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -5794,13 +5997,15 @@
       }
     },
     "node_modules/@smithy/fetch-http-handler": {
-      "version": "5.0.1",
+      "version": "5.3.6",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.3.6.tgz",
+      "integrity": "sha512-3+RG3EA6BBJ/ofZUeTFJA7mHfSYrZtQIrDP9dI8Lf7X6Jbos2jptuLrAAteDiFVrmbEmLSuRG/bUKzfAXk7dhg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/protocol-http": "^5.0.1",
-        "@smithy/querystring-builder": "^4.0.1",
-        "@smithy/types": "^4.1.0",
-        "@smithy/util-base64": "^4.0.0",
+        "@smithy/protocol-http": "^5.3.5",
+        "@smithy/querystring-builder": "^4.2.5",
+        "@smithy/types": "^4.9.0",
+        "@smithy/util-base64": "^4.3.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -5857,7 +6062,9 @@
       }
     },
     "node_modules/@smithy/is-array-buffer": {
-      "version": "4.0.0",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-4.2.0.tgz",
+      "integrity": "sha512-DZZZBvC7sjcYh4MazJSGiWMI2L7E0oCiRHREDzIxi/M2LY79/21iXt6aPLHge82wi5LsuRF5A06Ds3+0mlh6CQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -5891,16 +6098,18 @@
       }
     },
     "node_modules/@smithy/middleware-endpoint": {
-      "version": "4.0.3",
+      "version": "4.3.10",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-4.3.10.tgz",
+      "integrity": "sha512-SoAag3QnWBFoXjwa1jenEThkzJYClidZUyqsLKwWZ8kOlZBwehrLBp4ygVDjNEM2a2AamCQ2FBA/HuzKJ/LiTA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.1.2",
-        "@smithy/middleware-serde": "^4.0.2",
-        "@smithy/node-config-provider": "^4.0.1",
-        "@smithy/shared-ini-file-loader": "^4.0.1",
-        "@smithy/types": "^4.1.0",
-        "@smithy/url-parser": "^4.0.1",
-        "@smithy/util-middleware": "^4.0.1",
+        "@smithy/core": "^3.18.3",
+        "@smithy/middleware-serde": "^4.2.5",
+        "@smithy/node-config-provider": "^4.3.5",
+        "@smithy/shared-ini-file-loader": "^4.4.0",
+        "@smithy/types": "^4.9.0",
+        "@smithy/url-parser": "^4.2.5",
+        "@smithy/util-middleware": "^4.2.5",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -5908,12 +6117,14 @@
       }
     },
     "node_modules/@smithy/middleware-endpoint/node_modules/@smithy/node-config-provider": {
-      "version": "4.0.1",
+      "version": "4.3.5",
+      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-4.3.5.tgz",
+      "integrity": "sha512-UTurh1C4qkVCtqggI36DGbLB2Kv8UlcFdMXDcWMbqVY2uRg0XmT9Pb4Vj6oSQ34eizO1fvR0RnFV4Axw4IrrAg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/property-provider": "^4.0.1",
-        "@smithy/shared-ini-file-loader": "^4.0.1",
-        "@smithy/types": "^4.1.0",
+        "@smithy/property-provider": "^4.2.5",
+        "@smithy/shared-ini-file-loader": "^4.4.0",
+        "@smithy/types": "^4.9.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -5963,10 +6174,13 @@
       }
     },
     "node_modules/@smithy/middleware-serde": {
-      "version": "4.0.2",
+      "version": "4.2.5",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-4.2.5.tgz",
+      "integrity": "sha512-La1ldWTJTZ5NqQyPqnCNeH9B+zjFhrNoQIL1jTh4zuqXRlmXhxYHhMtI1/92OlnoAtp6JoN7kzuwhWoXrBwPqg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.1.0",
+        "@smithy/protocol-http": "^5.3.5",
+        "@smithy/types": "^4.9.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -5974,10 +6188,12 @@
       }
     },
     "node_modules/@smithy/middleware-stack": {
-      "version": "4.0.1",
+      "version": "4.2.5",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-4.2.5.tgz",
+      "integrity": "sha512-bYrutc+neOyWxtZdbB2USbQttZN0mXaOyYLIsaTbJhFsfpXyGWUxJpEuO1rJ8IIJm2qH4+xJT0mxUSsEDTYwdQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.1.0",
+        "@smithy/types": "^4.9.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -6030,13 +6246,15 @@
       }
     },
     "node_modules/@smithy/node-http-handler": {
-      "version": "4.0.2",
+      "version": "4.4.5",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.4.5.tgz",
+      "integrity": "sha512-CMnzM9R2WqlqXQGtIlsHMEZfXKJVTIrqCNoSd/QpAyp+Dw0a1Vps13l6ma1fH8g7zSPNsA59B/kWgeylFuA/lw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/abort-controller": "^4.0.1",
-        "@smithy/protocol-http": "^5.0.1",
-        "@smithy/querystring-builder": "^4.0.1",
-        "@smithy/types": "^4.1.0",
+        "@smithy/abort-controller": "^4.2.5",
+        "@smithy/protocol-http": "^5.3.5",
+        "@smithy/querystring-builder": "^4.2.5",
+        "@smithy/types": "^4.9.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -6044,10 +6262,12 @@
       }
     },
     "node_modules/@smithy/property-provider": {
-      "version": "4.0.1",
+      "version": "4.2.5",
+      "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-4.2.5.tgz",
+      "integrity": "sha512-8iLN1XSE1rl4MuxvQ+5OSk/Zb5El7NJZ1td6Tn+8dQQHIjp59Lwl6bd0+nzw6SKm2wSSriH2v/I9LPzUic7EOg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.1.0",
+        "@smithy/types": "^4.9.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -6055,10 +6275,12 @@
       }
     },
     "node_modules/@smithy/protocol-http": {
-      "version": "5.0.1",
+      "version": "5.3.5",
+      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.3.5.tgz",
+      "integrity": "sha512-RlaL+sA0LNMp03bf7XPbFmT5gN+w3besXSWMkA8rcmxLSVfiEXElQi4O2IWwPfxzcHkxqrwBFMbngB8yx/RvaQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.1.0",
+        "@smithy/types": "^4.9.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -6066,11 +6288,13 @@
       }
     },
     "node_modules/@smithy/querystring-builder": {
-      "version": "4.0.1",
+      "version": "4.2.5",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-4.2.5.tgz",
+      "integrity": "sha512-y98otMI1saoajeik2kLfGyRp11e5U/iJYH/wLCh3aTV/XutbGT9nziKGkgCaMD1ghK7p6htHMm6b6scl9JRUWg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.1.0",
-        "@smithy/util-uri-escape": "^4.0.0",
+        "@smithy/types": "^4.9.0",
+        "@smithy/util-uri-escape": "^4.2.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -6078,10 +6302,12 @@
       }
     },
     "node_modules/@smithy/querystring-parser": {
-      "version": "4.0.1",
+      "version": "4.2.5",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-4.2.5.tgz",
+      "integrity": "sha512-031WCTdPYgiQRYNPXznHXof2YM0GwL6SeaSyTH/P72M1Vz73TvCNH2Nq8Iu2IEPq9QP2yx0/nrw5YmSeAi/AjQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.1.0",
+        "@smithy/types": "^4.9.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -6099,10 +6325,12 @@
       }
     },
     "node_modules/@smithy/shared-ini-file-loader": {
-      "version": "4.0.1",
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-4.4.0.tgz",
+      "integrity": "sha512-5WmZ5+kJgJDjwXXIzr1vDTG+RhF9wzSODQBfkrQ2VVkYALKGvZX1lgVSxEkgicSAFnFhPj5rudJV0zoinqS0bA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.1.0",
+        "@smithy/types": "^4.9.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -6110,16 +6338,18 @@
       }
     },
     "node_modules/@smithy/signature-v4": {
-      "version": "5.0.1",
+      "version": "5.3.5",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.3.5.tgz",
+      "integrity": "sha512-xSUfMu1FT7ccfSXkoLl/QRQBi2rOvi3tiBZU2Tdy3I6cgvZ6SEi9QNey+lqps/sJRnogIS+lq+B1gxxbra2a/w==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/is-array-buffer": "^4.0.0",
-        "@smithy/protocol-http": "^5.0.1",
-        "@smithy/types": "^4.1.0",
-        "@smithy/util-hex-encoding": "^4.0.0",
-        "@smithy/util-middleware": "^4.0.1",
-        "@smithy/util-uri-escape": "^4.0.0",
-        "@smithy/util-utf8": "^4.0.0",
+        "@smithy/is-array-buffer": "^4.2.0",
+        "@smithy/protocol-http": "^5.3.5",
+        "@smithy/types": "^4.9.0",
+        "@smithy/util-hex-encoding": "^4.2.0",
+        "@smithy/util-middleware": "^4.2.5",
+        "@smithy/util-uri-escape": "^4.2.0",
+        "@smithy/util-utf8": "^4.2.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -6127,15 +6357,17 @@
       }
     },
     "node_modules/@smithy/smithy-client": {
-      "version": "4.1.3",
+      "version": "4.9.6",
+      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-4.9.6.tgz",
+      "integrity": "sha512-hGz42hggqReicRRZUvrKDQiAmoJnx1Q+XfAJnYAGu544gOfxQCAC3hGGD7+Px2gEUUxB/kKtQV7LOtBRNyxteQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.1.2",
-        "@smithy/middleware-endpoint": "^4.0.3",
-        "@smithy/middleware-stack": "^4.0.1",
-        "@smithy/protocol-http": "^5.0.1",
-        "@smithy/types": "^4.1.0",
-        "@smithy/util-stream": "^4.0.2",
+        "@smithy/core": "^3.18.3",
+        "@smithy/middleware-endpoint": "^4.3.10",
+        "@smithy/middleware-stack": "^4.2.5",
+        "@smithy/protocol-http": "^5.3.5",
+        "@smithy/types": "^4.9.0",
+        "@smithy/util-stream": "^4.5.6",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -6143,7 +6375,9 @@
       }
     },
     "node_modules/@smithy/types": {
-      "version": "4.1.0",
+      "version": "4.9.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.9.0.tgz",
+      "integrity": "sha512-MvUbdnXDTwykR8cB1WZvNNwqoWVaTRA0RLlLmf/cIFNMM2cKWz01X4Ly6SMC4Kks30r8tT3Cty0jmeWfiuyHTA==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -6153,11 +6387,13 @@
       }
     },
     "node_modules/@smithy/url-parser": {
-      "version": "4.0.1",
+      "version": "4.2.5",
+      "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-4.2.5.tgz",
+      "integrity": "sha512-VaxMGsilqFnK1CeBX+LXnSuaMx4sTL/6znSZh2829txWieazdVxr54HmiyTsIbpOTLcf5nYpq9lpzmwRdxj6rQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/querystring-parser": "^4.0.1",
-        "@smithy/types": "^4.1.0",
+        "@smithy/querystring-parser": "^4.2.5",
+        "@smithy/types": "^4.9.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -6165,11 +6401,13 @@
       }
     },
     "node_modules/@smithy/util-base64": {
-      "version": "4.0.0",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-4.3.0.tgz",
+      "integrity": "sha512-GkXZ59JfyxsIwNTWFnjmFEI8kZpRNIBfxKjv09+nkAWPt/4aGaEWMM04m4sxgNVWkbt2MdSvE3KF/PfX4nFedQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/util-buffer-from": "^4.0.0",
-        "@smithy/util-utf8": "^4.0.0",
+        "@smithy/util-buffer-from": "^4.2.0",
+        "@smithy/util-utf8": "^4.2.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -6177,7 +6415,9 @@
       }
     },
     "node_modules/@smithy/util-body-length-browser": {
-      "version": "4.0.0",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-browser/-/util-body-length-browser-4.2.0.tgz",
+      "integrity": "sha512-Fkoh/I76szMKJnBXWPdFkQJl2r9SjPt3cMzLdOB6eJ4Pnpas8hVoWPYemX/peO0yrrvldgCUVJqOAjUrOLjbxg==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -6197,10 +6437,12 @@
       }
     },
     "node_modules/@smithy/util-buffer-from": {
-      "version": "4.0.0",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-4.2.0.tgz",
+      "integrity": "sha512-kAY9hTKulTNevM2nlRtxAG2FQ3B2OR6QIrPY3zE5LqJy1oxzmgBGsHLWTcNhWXKchgA0WHW+mZkQrng/pgcCew==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/is-array-buffer": "^4.0.0",
+        "@smithy/is-array-buffer": "^4.2.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -6208,7 +6450,9 @@
       }
     },
     "node_modules/@smithy/util-config-provider": {
-      "version": "4.0.0",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-config-provider/-/util-config-provider-4.2.0.tgz",
+      "integrity": "sha512-YEjpl6XJ36FTKmD+kRJJWYvrHeUvm5ykaUS5xK+6oXffQPHeEM4/nXlZPe+Wu0lsgRUcNZiliYNh/y7q9c2y6Q==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -6300,7 +6544,9 @@
       }
     },
     "node_modules/@smithy/util-hex-encoding": {
-      "version": "4.0.0",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-4.2.0.tgz",
+      "integrity": "sha512-CCQBwJIvXMLKxVbO88IukazJD9a4kQ9ZN7/UMGBjBcJYvatpWk+9g870El4cB8/EJxfe+k+y0GmR9CAzkF+Nbw==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -6310,10 +6556,12 @@
       }
     },
     "node_modules/@smithy/util-middleware": {
-      "version": "4.0.1",
+      "version": "4.2.5",
+      "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-4.2.5.tgz",
+      "integrity": "sha512-6Y3+rvBF7+PZOc40ybeZMcGln6xJGVeY60E7jy9Mv5iKpMJpHgRE6dKy9ScsVxvfAYuEX4Q9a65DQX90KaQ3bA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.1.0",
+        "@smithy/types": "^4.9.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -6333,16 +6581,18 @@
       }
     },
     "node_modules/@smithy/util-stream": {
-      "version": "4.0.2",
+      "version": "4.5.6",
+      "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-4.5.6.tgz",
+      "integrity": "sha512-qWw/UM59TiaFrPevefOZ8CNBKbYEP6wBAIlLqxn3VAIo9rgnTNc4ASbVrqDmhuwI87usnjhdQrxodzAGFFzbRQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/fetch-http-handler": "^5.0.1",
-        "@smithy/node-http-handler": "^4.0.2",
-        "@smithy/types": "^4.1.0",
-        "@smithy/util-base64": "^4.0.0",
-        "@smithy/util-buffer-from": "^4.0.0",
-        "@smithy/util-hex-encoding": "^4.0.0",
-        "@smithy/util-utf8": "^4.0.0",
+        "@smithy/fetch-http-handler": "^5.3.6",
+        "@smithy/node-http-handler": "^4.4.5",
+        "@smithy/types": "^4.9.0",
+        "@smithy/util-base64": "^4.3.0",
+        "@smithy/util-buffer-from": "^4.2.0",
+        "@smithy/util-hex-encoding": "^4.2.0",
+        "@smithy/util-utf8": "^4.2.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -6350,7 +6600,9 @@
       }
     },
     "node_modules/@smithy/util-uri-escape": {
-      "version": "4.0.0",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-4.2.0.tgz",
+      "integrity": "sha512-igZpCKV9+E/Mzrpq6YacdTQ0qTiLm85gD6N/IrmyDvQFA4UnU3d5g3m8tMT/6zG/vVkWSU+VxeUyGonL62DuxA==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -6360,10 +6612,12 @@
       }
     },
     "node_modules/@smithy/util-utf8": {
-      "version": "4.0.0",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.2.0.tgz",
+      "integrity": "sha512-zBPfuzoI8xyBtR2P6WQj63Rz8i3AmfAaJLuNG8dWsfvPe8lO4aCPYLn879mEgHndZH1zQ2oXmG8O1GGzzaoZiw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/util-buffer-from": "^4.0.0",
+        "@smithy/util-buffer-from": "^4.2.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -6376,6 +6630,18 @@
       "dependencies": {
         "@smithy/abort-controller": "^4.0.1",
         "@smithy/types": "^4.1.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/uuid": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@smithy/uuid/-/uuid-1.1.0.tgz",
+      "integrity": "sha512-4aUIteuyxtBUhVdiQqcDhKFitwfd9hqoSDYY2KRXiWtgoWJ9Bmise+KfEPDiVHWeJepvF8xJO9/9+WDIciMFFw==",
+      "license": "Apache-2.0",
+      "dependencies": {
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -30063,6 +30329,7 @@
         "@aws-sdk/client-lambda": "^3.637.0",
         "@aws-sdk/client-s3": "^3.637.0",
         "@aws-sdk/lib-dynamodb": "^3.637.0",
+        "@aws-sdk/s3-request-presigner": "^3.637.0",
         "@babel/core": "^7.25.2",
         "@babel/plugin-transform-class-properties": "^7.25.4",
         "@babel/plugin-transform-nullish-coalescing-operator": "7.24.7",

--- a/packages/geoprocessing/package.json
+++ b/packages/geoprocessing/package.json
@@ -64,6 +64,7 @@
     "@aws-sdk/client-lambda": "^3.637.0",
     "@aws-sdk/client-s3": "^3.637.0",
     "@aws-sdk/lib-dynamodb": "^3.637.0",
+    "@aws-sdk/s3-request-presigner": "^3.637.0",
     "@babel/core": "^7.25.2",
     "@babel/plugin-transform-class-properties": "^7.25.4",
     "@babel/plugin-transform-nullish-coalescing-operator": "7.24.7",

--- a/packages/geoprocessing/scripts/aws/buckets.ts
+++ b/packages/geoprocessing/scripts/aws/buckets.ts
@@ -11,13 +11,8 @@ export const createPublicBuckets = (
     dataset: new Bucket(stack, `GpDatasetBucket`, {
       bucketName: `gp-${stack.props.projectName}-datasets`,
       versioned: false,
-      blockPublicAccess: new BlockPublicAccess({
-        blockPublicPolicy: false,
-        blockPublicAcls: false,
-        restrictPublicBuckets: false,
-        ignorePublicAcls: false,
-      }),
-      publicReadAccess: true,
+      blockPublicAccess: BlockPublicAccess.BLOCK_ALL,
+      publicReadAccess: false,
       cors: [
         {
           allowedOrigins: ["*"],

--- a/packages/geoprocessing/scripts/aws/types.ts
+++ b/packages/geoprocessing/scripts/aws/types.ts
@@ -49,13 +49,14 @@ export interface GpDynamoTables {
 
 export interface GpPublicBuckets {
   /**
-   * Publicly accessible bucket for large datasets that need to be stored outside of project code assets
-   * Location is not published or able to be listed.  Can be read by gp functions whether in Lambda, local, or CI
+   * Private bucket for large datasets that need to be stored outside of project code assets.
+   * Access is restricted to Lambda functions deployed in the stack via IAM policies.
+   * Can be read by gp functions in Lambda with proper permissions.
    */
   dataset: Bucket;
   /**
-   * Create publicly accessible bucket for function results that aren't simple JSON serializable
-   * Location is not published or able to be listed.
+   * Private bucket for function results that aren't simple JSON serializable.
+   * Access is restricted to Lambda functions deployed in the stack via IAM policies.
    */
   result?: Bucket;
 }

--- a/packages/geoprocessing/src/dataproviders/cog.ts
+++ b/packages/geoprocessing/src/dataproviders/cog.ts
@@ -1,5 +1,6 @@
 import geoblaze from "geoblaze";
 import { callWithRetry } from "../helpers/callWithRetry.js";
+import { genPresignedUrl } from "./presignedUrl.js";
 import "./fetchPolyfill.js";
 
 /**
@@ -11,7 +12,11 @@ import "./fetchPolyfill.js";
  */
 export const loadCog = async (url: string) => {
   if (process.env.NODE_ENV !== "test") console.log("loadCog", url);
-  return await callWithRetry(geoblaze.parse, [url], {
+
+  // Convert to presigned URL if running in Lambda with private S3 bucket
+  const signedUrl = await genPresignedUrl(url);
+
+  return await callWithRetry(geoblaze.parse, [signedUrl], {
     ifErrorMsgContains: "fetch failed",
   });
 };

--- a/packages/geoprocessing/src/dataproviders/flatgeobuf.ts
+++ b/packages/geoprocessing/src/dataproviders/flatgeobuf.ts
@@ -4,6 +4,7 @@ import { takeAsync } from "flatgeobuf/lib/mjs/streams/utils.js";
 import { deserialize } from "flatgeobuf/lib/mjs/geojson.js";
 import { BBox, Feature, FeatureCollection, Geometry } from "../types/index.js";
 import { callWithRetry } from "../helpers/callWithRetry.js";
+import { genPresignedUrl } from "./presignedUrl.js";
 import "./fetchPolyfill.js";
 
 export interface FgBoundingBox {
@@ -48,6 +49,9 @@ export async function loadFgb<F extends Feature<Geometry>>(
   url: string,
   bbox?: BBox,
 ) {
+  // Convert to presigned URL if running in Lambda with private S3 bucket
+  const signedUrl = await genPresignedUrl(url);
+
   const fgBox = (() => {
     if (!bbox && !Array.isArray(bbox)) {
       return fgBoundingBox([-180, -90, 180, 90]); // fallback to entire world
@@ -64,7 +68,7 @@ export async function loadFgb<F extends Feature<Geometry>>(
     takeAsync(deserialize(url, fgBox) as AsyncGenerator);
 
   // retry up to 3 times if SocketError
-  const features: F[] = (await callWithRetry(takeFeatures, [url, fgBox], {
+  const features: F[] = (await callWithRetry(takeFeatures, [signedUrl, fgBox], {
     ifErrorMsgContains: "fetch failed",
   })) as F[];
 

--- a/packages/geoprocessing/src/dataproviders/index.ts
+++ b/packages/geoprocessing/src/dataproviders/index.ts
@@ -2,3 +2,4 @@ export * from "./cog.js";
 export * from "./flatgeobuf.js";
 export * from "./getDatasourceFeatures.js";
 export * from "./getFeaturesForSketchBBoxes.js";
+export * from "./presignedUrl.js";

--- a/packages/geoprocessing/src/dataproviders/presignedUrl.test.ts
+++ b/packages/geoprocessing/src/dataproviders/presignedUrl.test.ts
@@ -1,0 +1,107 @@
+import { describe, test, expect, vi, beforeEach, afterEach } from "vitest";
+import { genPresignedUrl } from "./presignedUrl.js";
+
+describe("genPresignedUrl", () => {
+  const originalEnv = process.env.AWS_LAMBDA_FUNCTION_NAME;
+
+  beforeEach(() => {
+    // Clean up environment before each test
+    delete process.env.AWS_LAMBDA_FUNCTION_NAME;
+  });
+
+  afterEach(() => {
+    // Restore original environment after each test
+    if (originalEnv === undefined) {
+      delete process.env.AWS_LAMBDA_FUNCTION_NAME;
+    } else {
+      process.env.AWS_LAMBDA_FUNCTION_NAME = originalEnv;
+    }
+  });
+
+  test("should return original URL when not in Lambda environment", async () => {
+    const url =
+      "https://gp-test-project-datasets.s3.us-west-1.amazonaws.com/data.fgb";
+    const result = await genPresignedUrl(url);
+    expect(result).toBe(url);
+  });
+
+  test("should return original URL for non-S3 URLs", async () => {
+    const url = "https://example.com/data.fgb";
+    const result = await genPresignedUrl(url);
+    expect(result).toBe(url);
+  });
+
+  test("should return original URL for http (non-https) URLs", async () => {
+    const url = "http://example.com/data.fgb";
+    const result = await genPresignedUrl(url);
+    expect(result).toBe(url);
+  });
+
+  test("should return original URL for relative URLs", async () => {
+    const url = "/data/test.fgb";
+    const result = await genPresignedUrl(url);
+    expect(result).toBe(url);
+  });
+
+  test("should parse S3 URL correctly and identify bucket, region, and key", async () => {
+    const url =
+      "https://gp-test-project-datasets.s3.us-west-1.amazonaws.com/subfolder/data.fgb";
+
+    // Not in Lambda, so should return original
+    const result = await genPresignedUrl(url);
+    expect(result).toBe(url);
+
+    // Verify URL pattern matching by testing the regex
+    const s3UrlMatch = url.match(
+      /^https:\/\/([^.]+)\.s3\.([^.]+)\.amazonaws\.com\/(.+)$/,
+    );
+    expect(s3UrlMatch).not.toBeNull();
+    if (s3UrlMatch) {
+      const [, bucket, region, key] = s3UrlMatch;
+      expect(bucket).toBe("gp-test-project-datasets");
+      expect(region).toBe("us-west-1");
+      expect(key).toBe("subfolder/data.fgb");
+    }
+  });
+
+  test("should handle URL with complex key path", async () => {
+    const url =
+      "https://my-bucket.s3.eu-west-2.amazonaws.com/path/to/deeply/nested/file.tif";
+
+    const s3UrlMatch = url.match(
+      /^https:\/\/([^.]+)\.s3\.([^.]+)\.amazonaws\.com\/(.+)$/,
+    );
+    expect(s3UrlMatch).not.toBeNull();
+    if (s3UrlMatch) {
+      const [, bucket, region, key] = s3UrlMatch;
+      expect(bucket).toBe("my-bucket");
+      expect(region).toBe("eu-west-2");
+      expect(key).toBe("path/to/deeply/nested/file.tif");
+    }
+  });
+
+  test("should not match S3 URL without region", async () => {
+    // Old-style S3 URL format (s3.amazonaws.com without region)
+    const url = "https://my-bucket.s3.amazonaws.com/data.fgb";
+
+    const s3UrlMatch = url.match(
+      /^https:\/\/([^.]+)\.s3\.([^.]+)\.amazonaws\.com\/(.+)$/,
+    );
+    // Should not match because region segment is just "amazonaws"
+    expect(s3UrlMatch).toBeNull();
+  });
+
+  test("should return original URL when in Lambda but URL is external", async () => {
+    // Simulate Lambda environment
+    process.env.AWS_LAMBDA_FUNCTION_NAME = "test-function";
+
+    const url = "https://external-data-source.com/data.fgb";
+    const result = await genPresignedUrl(url);
+    expect(result).toBe(url);
+  });
+
+  // Note: We cannot easily test the actual presigned URL generation without
+  // mocking the AWS SDK, which would require more complex setup.
+  // In a real Lambda environment with proper IAM permissions, the presigned
+  // URL generation is tested through integration tests.
+});

--- a/packages/geoprocessing/src/dataproviders/presignedUrl.ts
+++ b/packages/geoprocessing/src/dataproviders/presignedUrl.ts
@@ -1,0 +1,55 @@
+import { S3Client, GetObjectCommand } from "@aws-sdk/client-s3";
+import { getSignedUrl } from "@aws-sdk/s3-request-presigner";
+
+/**
+ * Generates a presigned URL for an S3 object if running in Lambda environment
+ * and the URL points to an S3 bucket. Otherwise returns the original URL.
+ *
+ * @param url - The S3 URL to potentially convert to a presigned URL
+ * @param expiresIn - Number of seconds until the presigned URL expires (default: 3600 = 1 hour)
+ * @returns Presigned URL if in Lambda with S3 URL, otherwise original URL
+ */
+export async function genPresignedUrl(
+  url: string,
+  expiresIn: number = 900,
+): Promise<string> {
+  // Only generate presigned URLs when running in Lambda (not in test or local dev)
+  const isLambda = process.env.AWS_LAMBDA_FUNCTION_NAME !== undefined;
+
+  if (!isLambda) {
+    return url;
+  }
+
+  // Check if this is an S3 URL that needs signing
+  const s3UrlMatch = url.match(
+    /^https:\/\/([^.]+)\.s3\.([^.]+)\.amazonaws\.com\/(.+)$/,
+  );
+
+  if (!s3UrlMatch) {
+    // Not an S3 URL, return as-is
+    return url;
+  }
+
+  const [, bucket, region, key] = s3UrlMatch;
+
+  try {
+    const client = new S3Client({ region });
+    const command = new GetObjectCommand({
+      Bucket: bucket,
+      Key: key,
+    });
+
+    const presignedUrl = await getSignedUrl(client, command, { expiresIn });
+
+    if (process.env.NODE_ENV !== "test") {
+      console.log(`Generated presigned URL for s3://${bucket}/${key}`);
+    }
+
+    return presignedUrl;
+  } catch (error) {
+    console.error("Error generating presigned URL:", error);
+    throw new Error(
+      `Failed to generate presigned URL for ${url}: ${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
+}

--- a/packages/geoprocessing/src/dataproviders/presignedUrl.ts
+++ b/packages/geoprocessing/src/dataproviders/presignedUrl.ts
@@ -2,33 +2,25 @@ import { S3Client, GetObjectCommand } from "@aws-sdk/client-s3";
 import { getSignedUrl } from "@aws-sdk/s3-request-presigner";
 
 /**
- * Generates a presigned URL for an S3 object if running in Lambda environment
+ * Generates a presigned URL for an S3 object if in Lambda environment
  * and the URL points to an S3 bucket. Otherwise returns the original URL.
  *
- * @param url - The S3 URL to potentially convert to a presigned URL
- * @param expiresIn - Number of seconds until the presigned URL expires (default: 3600 = 1 hour)
+ * @param url - The S3 URL to convert to a presigned URL
+ * @param expiresIn - Seconds until the presigned URL expires (default: 15 minutes)
  * @returns Presigned URL if in Lambda with S3 URL, otherwise original URL
  */
 export async function genPresignedUrl(
   url: string,
   expiresIn: number = 900,
 ): Promise<string> {
-  // Only generate presigned URLs when running in Lambda (not in test or local dev)
-  const isLambda = process.env.AWS_LAMBDA_FUNCTION_NAME !== undefined;
+  // Only presign in Lambda
+  if (process.env.AWS_LAMBDA_FUNCTION_NAME === undefined) return url;
 
-  if (!isLambda) {
-    return url;
-  }
-
-  // Check if this is an S3 URL that needs signing
+  // Check this is an S3 URL
   const s3UrlMatch = url.match(
     /^https:\/\/([^.]+)\.s3\.([^.]+)\.amazonaws\.com\/(.+)$/,
   );
-
-  if (!s3UrlMatch) {
-    // Not an S3 URL, return as-is
-    return url;
-  }
+  if (!s3UrlMatch) return url;
 
   const [, bucket, region, key] = s3UrlMatch;
 


### PR DESCRIPTION
Closes #84. 

Makes new and existing s3 datasets buckets private. `loadFgb()` and `loadCog()` now generate a presigned URL in lambda environment to fetch data. 